### PR TITLE
feat: 内置解析引擎 + 三前端 + 应用层协议 + 全面加固

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,22 @@ project(EasyTshark_xuanyuan VERSION 1.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/output")
+# 关闭编译器 GNU 扩展：用严格 -std=c++11 而非 -std=gnu++11，真正锁死 C++11 目标
+# （本项目刻意固定 C++11，贴合保守工具链），让误用的 GNU/更高标准构造在本机就暴露。
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 单 config 生成器（Makefile/Ninja）在未指定 CMAKE_BUILD_TYPE 时，编译标志为空
+# ——即 -O0 无优化。解析引擎是纯计算热点，-O0→-O2 通常有数倍差距，故给个默认值。
+# 多 config 生成器（Visual Studio / Xcode）由 --config 决定，带 CMAKE_CONFIGURATION_TYPES，
+# 此处不覆盖它们。用户仍可用 -DCMAKE_BUILD_TYPE=Debug 显式改回。
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "构建类型（默认 Release）" FORCE)
+endif()
+# 产物输出目录：默认 output/（源码树内，脚本/README 的约定路径）；
+# 需要 out-of-source 干净构建时可 -DEASYTSHARK_OUTPUT_DIR=/path 覆盖。
+set(EASYTSHARK_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/output" CACHE PATH
+    "构建产物输出目录（默认源码树内 output/）")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${EASYTSHARK_OUTPUT_DIR}")
 
 file(COPY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
@@ -41,9 +56,12 @@ set(LIB_SOURCES
     src/LiveCapture.cpp
     src/FlowMonitor.cpp
     src/PdmlToJsonConverter.cpp
-    src/xdb_bench.cc
+    src/NativePacketParser.cpp
+    src/NativeAnalyzer.cpp
+    src/NativeCapture.cpp
     src/xdb_search.cc
     src/processUtil.cpp
+    src/web/WebServer.cpp
 )
 
 # I/O 多路复用 + 非阻塞管道读取：按平台二选一，接口一致，业务代码平台无关。
@@ -91,6 +109,21 @@ elseif(WIN32)
     target_link_libraries(tshark_lib ws2_32)
 else()
     target_link_libraries(tshark_lib pthread dl sqlite3)
+endif()
+
+# 自研引擎的实时抓包依赖 libpcap（BSD 许可）：macOS 系统自带；Linux 需 libpcap-dev；
+# Windows 需 Npcap SDK。找不到时编译仍通过——NativeCapture 退化为“无法抓包”，
+# 离线解析（NativeAnalyzer）不依赖 libpcap，始终可用。
+find_library(PCAP_LIBRARY NAMES pcap)
+find_path(PCAP_INCLUDE_DIR NAMES pcap.h)
+if(PCAP_LIBRARY AND PCAP_INCLUDE_DIR)
+    target_compile_definitions(tshark_lib PUBLIC EASYTSHARK_HAVE_LIBPCAP=1)
+    target_include_directories(tshark_lib PUBLIC ${PCAP_INCLUDE_DIR})
+    # 注意：tshark_lib 已用 plain signature 链接过系统库，这里保持 plain（不写 PUBLIC 关键字）
+    target_link_libraries(tshark_lib ${PCAP_LIBRARY})
+    message(STATUS "libpcap 已找到：${PCAP_LIBRARY}（自研实时抓包可用）")
+else()
+    message(STATUS "libpcap 未找到：实时抓包仅 tshark 路径可用；离线解析不受影响")
 endif()
 
 # 主可执行文件

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # EasyTshark - 网络数据包捕获与分析工具
 
-本仓库是 EasyTshark 的 **C++ 版本**，从零用 C++11 重写核心抓包与分析逻辑，供学习网络编程、进程管理、SQLite 集成参考。社区正式版由 **“轩辕之风”老师** 维护，见 [easytshark.com](https://www.easytshark.com/)。
+社区正式版由 **“轩辕之风”老师** 维护，见 [easytshark.com](https://www.easytshark.com/)。
 
-EasyTshark 基于 tshark，支持实时抓包与离线 PCAP 分析、SQLite 存储、XML/JSON 格式转换，提供**命令行**、**原生图形界面**与**Web 界面**三种前端。
+EasyTshark 支持实时抓包与离线 PCAP 分析、SQLite 存储、XML/JSON 格式转换，提供**命令行**、**原生图形界面**与**Web 界面**三种前端。
+
+**无需预装 Wireshark 即可开箱即用**：项目内置自研解析引擎（libpcap 抓包 + 内置协议解析），覆盖常用协议（Ethernet/VLAN/ARP/IPv4/IPv6/ICMP/TCP/UDP/DNS/HTTP/TLS/SSH 等）。安装 Wireshark 的 tshark 后可解锁**完整协议详情树、显示过滤、流量趋势**等增强能力（自动检测，无需配置）。
 
 > 早期未完成的实现（仅含后端部分，无 GUI）保存在 [`feature/V1`](../../tree/feature/V1) 分支；当前主线是重构后的完整版本。
 
@@ -12,11 +14,14 @@ EasyTshark 基于 tshark，支持实时抓包与离线 PCAP 分析、SQLite 存�
 
 - **双模式**：实时抓包（从网卡捕获）/ 离线分析（解析已有 PCAP 文件）
 - **三前端**：命令行 `tshark_main`（交互式菜单）/ 图形界面 `tshark_gui`（Dear ImGui，包列表 / 十六进制 / 协议详情树 / 显示过滤）/ Web 界面 `tshark_web`（headless 服务器上跑引擎，浏览器远程访问同一套富界面）
+- **双引擎自动切换**：检测到 tshark 用其完整能力；未安装时自动降级到内置引擎（功能一致：抓包/解析/hex/详情树/常用过滤/结构化查询）
 - **数据存储**：捕获的数据包存入 SQLite，支持快速查询
-- **格式转换**：PCAP → tshark PDML(XML) → JSON
-- **IP 地理位置**：基于 ip2region 自动解析归属地
+- **格式转换**：PCAP → tshark PDML(XML) → JSON；报文快照可导出 CSV（Web 界面有导出按钮）；离线分析支持 **pcapng**（自动识别，hex 视图正确）
+- **IP 地理位置**：基于 ip2region 自动解析归属地（库文件缺失时优雅降级为空归属地，不再退出程序）
 - **tshark 自动探测**：依次尝试环境变量 `EASYTSHARK_TSHARK`、平台默认路径、`PATH`、Windows 注册表；也可手动指定（无需重编译）
-- **查询**：支持 MAC / IP / 端口 / 归属地模糊匹配，结果可导出 JSON
+- **查询**：支持 MAC / IP / 端口 / 归属地模糊匹配（`*` 通配；字面 `%`/`_` 已转义），结果可导出 JSON
+- **Web 安全**：所有 `/api/*` 需 `X-Auth-Token`（启动时生成打印，可用 `EASYTSHARK_WEB_TOKEN`/`--token` 固定）+ Origin 校验；`/api/load` 与导出限用户主目录/`data/` 下
+- **大文件**：Web 报文列表分页拉取、实时缓冲有上限（长抓包丢弃最旧）；统计页带协议/IP 分布条形图
 
 ## 架构
 
@@ -39,7 +44,9 @@ EasyTshark 基于 tshark，支持实时抓包与离线 PCAP 分析、SQLite 存�
 ## 系统要求
 
 - **平台**：macOS（已验证）、Windows（MSVC，已支持）、Linux（与 macOS 共用 `poll` 实现，理论支持，待验证）
-- tshark（Wireshark 命令行工具）、SQLite3、C++11 编译器
+- **tshark（可选）**：未安装时使用内置引擎（覆盖常用协议）；安装 Wireshark 可获得完整协议详情/显示过滤/流量趋势
+- **libpcap**：内置引擎的实时抓包需要（macOS 系统自带；Linux 装 `libpcap-dev`；Windows 装 Npcap SDK）。未找到时编译仍通过，仅实时抓包不可用，离线解析不受影响
+- SQLite3、C++11 编译器
 - CMake 3.10+（若用 CMake 4.x 需加 `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`，脚本已内置）
 
 ## 依赖库
@@ -51,11 +58,11 @@ EasyTshark 基于 tshark，支持实时抓包与离线 PCAP 分析、SQLite 存�
 **1. 安装依赖**
 
 ```bash
-# macOS
+# macOS（wireshark 可选：装了解锁完整协议；不装也能用内置引擎）
 brew install --cask wireshark && brew install cmake
 
-# Linux (Debian/Ubuntu，命令待再次验证)
-sudo apt-get install -y build-essential cmake tshark libsqlite3-dev
+# Linux (Debian/Ubuntu，命令待再次验证；tshark/libpcap 均为可选依赖)
+sudo apt-get install -y build-essential cmake tshark libpcap-dev libsqlite3-dev
 
 # Windows：安装 Wireshark（提供 tshark.exe）与 VS 2022 Build Tools（C++ 工作负载）
 ```
@@ -85,7 +92,10 @@ Windows 下在普通 `cmd`（非 Git Bash）中运行 `scripts\build_windows.bat
 ```bash
 ./output/tshark_web                      # 默认 http://127.0.0.1:8080
 ./output/tshark_web --host 127.0.0.1 --port 9000   # 自定义 host/port（也可用环境变量 EASYTSHARK_WEB_HOST/PORT）
+./output/tshark_web --token mytoken      # 指定固定访问令牌（也可用环境变量 EASYTSHARK_WEB_TOKEN）
 ```
+
+**访问令牌**：Web 服务所有 `/api/*` 请求必须携带 `X-Auth-Token` 头（浏览器首次打开页面时输入服务器启动时打印的令牌，保存在 localStorage；API 场景用 curl 加 `-H "X-Auth-Token: <令牌>"`）。未指定时启动自动生成并打印。浏览器请求还校验 Origin 与 Host 一致，防 DNS rebinding / 跨站请求。
 
 远程访问请用 SSH 端口转发，**不要**把服务裸绑到 `0.0.0.0`（本服务会驱动特权抓包）：
 
@@ -119,8 +129,16 @@ ssh -L 8080:127.0.0.1:8080 user@server   # 本机浏览器开 http://127.0.0.1:8
 ├── third_party/        # vendored 第三方库
 ├── tests/              # 单元测试
 ├── resources/          # 运行所需资源（ip2region.xdb）
-└── output/             # 构建产物（gitignore）
+└── output/             # 构建产物（gitignore；可用 -DEASYTSHARK_OUTPUT_DIR= 覆盖）
 ```
+
+## 分支说明
+
+- `main`：主线，始终可构建可用的最新版本。
+- `feature/dev`：开发分支，与 `main` 保持同步（本地 merge --ff-only 推进），已包含 Web 前端、令牌认证、并发加固等新特性。
+- `feature/V1`：早期未完成的实现（仅含后端部分，无 GUI），仅作历史参考，不再维护。
+
+> 本地无权限推送时，可用 `git push origin main feature/dev` 同步远端；不建议在共享仓库上重写历史。
 
 ## 许可证
 

--- a/include/AnalysisSession.hpp
+++ b/include/AnalysisSession.hpp
@@ -1,6 +1,7 @@
 #ifndef AnalysisSession_hpp
 #define AnalysisSession_hpp
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -9,22 +10,19 @@
 
 #include "FlowMonitor.hpp"
 #include "LiveCapture.hpp"
+#include "NativeAnalyzer.hpp"
+#include "NativeCapture.hpp"
 #include "PcapAnalyzer.hpp"
 #include "PdmlToJsonConverter.hpp"
 #include "tsharkDataType.hpp"
 #include "utils.hpp"
 
-// 一次“分析会话”的门面（Facade）：把 PcapAnalyzer / SQLiteUtil /
-// PdmlToJsonConverter / LiveCapture / FlowMonitor 聚合到一处，对外只暴露
-// 面向意图的接口（载入、取包、取 hex、查询、抓包、流量趋势）。
+// “分析会话”门面（Facade）：聚合 PcapAnalyzer / SQLiteUtil / PdmlToJsonConverter /
+// LiveCapture / FlowMonitor，对外只暴露面向意图的接口，让 UI 与解析/抓包/入库实现解耦。
 //
-// 目的：让调用方（CLI 的 main、以及后续的 ImGui 前端）与解析/抓包/入库的
-// 具体实现解耦——UI 只依赖这层稳定接口，不直接触碰 tshark 细节。这里的
-// “前后端分离”是同进程内的“核心库 ↔ UI 层”边界，不是网络 C/S。
-//
-// 线程约定：packetCount / packetsSnapshot / flowTrendSnapshot 取的是
-// 数据的拷贝快照，加锁保护，可从 UI 线程安全调用；载入/抓包等写操作应在
-// 同一线程（或调用方自行串行化）发起。
+// 线程约定：packetCount / packetsSnapshot / flowTrendSnapshot 可从任意线程安全调用；
+// 载入/抓包等写操作须由调用方串行化。内部 analyzerMutex_ 令 getHex/getDetailTree/
+// queryDisplayFilter 与后台 analyzeAndStore 的 analyzer_ 访问互斥；capturing_ 为原子。
 class AnalysisSession
 {
 public:
@@ -35,13 +33,13 @@ public:
     AnalysisSession(const AnalysisSession&)            = delete;
     AnalysisSession& operator=(const AnalysisSession&) = delete;
 
-    // 载入并分析一个 pcap 文件：srcPath 必须非空，会按时间戳复制一份到
-    // dataDir/pcaps/ 下（历史不覆盖），随后解析入库。srcPath 为空直接返回失败。
+    // 载入并分析 pcap：按时间戳复制一份到 dataDir/pcaps/（历史不覆盖）再解析入库。
     bool loadPcap(const std::string& srcPath);
 
     // ---- 报文访问（读快照，线程安全）----
-    size_t                               packetCount() const;
-    std::vector<std::shared_ptr<Packet>> packetsSnapshot() const;
+    size_t packetCount() const;
+    // 返回共享快照（shared_ptr，无拷贝，内部原子交换，持有期间安全）。
+    std::shared_ptr<const std::vector<std::shared_ptr<Packet>>> packetsSnapshot() const;
 
     // 取指定帧号的原始字节（十六进制视图用）
     bool getHex(uint32_t frameNumber, std::vector<unsigned char>& out);
@@ -49,10 +47,10 @@ public:
     // 取指定帧号的协议分层树（详情面板逐层展开用）
     bool getDetailTree(uint32_t frameNumber, DetailNode& root);
 
-    // 用 tshark 显示过滤表达式（-Y）筛选当前报文集，回填匹配的报文子集。
-    // 匹配帧号由 tshark 求得，报文取自既有快照（保留正确 file_offset，hex 可用）。
+    // 用 tshark 显示过滤表达式（-Y）筛选当前报文集，回填匹配子集（沿用快照 file_offset）。
     bool queryDisplayFilter(const std::string&                    displayFilter,
-                            std::vector<std::shared_ptr<Packet>>& out);
+                            std::vector<std::shared_ptr<Packet>>& out,
+                            std::string* errorOut = nullptr);
 
     // 把当前载入/抓包的 pcap 另存到 destPath（工具栏“保存”用）。
     bool savePcapAs(const std::string& destPath);
@@ -63,12 +61,16 @@ public:
     // 将当前 pcap 导出为详细的 PDML JSON（协议逐层展开），中间产物 XML 写到 xmlPath。
     bool exportDetailJson(const std::string& xmlPath, const std::string& jsonPath);
 
+    // 把当前报文快照导出为 CSV（纯内存序列化，不依赖 tshark）。
+    bool exportPacketsCsv(const std::string& csvPath);
+
     // ---- 实时抓包 ----
     std::vector<AdapterInfo> listAdapters() const;
-    // 开始实时抓包。onPacket 非空时，每抓到一个包就在**抓包线程**回调一次（供 UI 实时追加，
-    // 调用方需自行加锁）；为空则仅落盘、停止后再统一解析。
+    // 开始实时抓包。onPacket 非空时每抓到一个包就在抓包线程回调一次（调用方需自行加锁）；
+    // 为空则仅落盘、停止后再统一解析。
     bool startLiveCapture(const std::string&           adapterName,
-                          LiveCapture::PacketCallback onPacket = nullptr);
+                          LiveCapture::PacketCallback onPacket = nullptr,
+                          int durationSeconds = 0);
     // 停止抓包，并把抓到的 capture.pcap 载入分析入库
     bool stopLiveCapture();
     bool isCapturing() const;
@@ -83,12 +85,14 @@ public:
     std::string        pcapPath() const;
     const std::string& tsharkPath() const { return tsharkPath_; }
 
-    // 运行时切换 tshark 路径（GUI 里手动指定 tshark.exe 用）：更新自身并同步给
-    // analyzer_/converter_；on-demand 创建的 LiveCapture/FlowMonitor 会从 tsharkPath_ 取新值。
+    // 当前后端引擎名：tshark（完整能力）或 native（内置引擎，无 tshark 时）。
+    std::string engineName() const { return native_ ? "native" : "tshark"; }
+
+    // 运行时切换 tshark 路径：更新自身并同步给 analyzer_/converter_，按需重估后端。
     void setTsharkPath(const std::string& path);
 
 private:
-    // 解析 pcapFilePath 并入库到 dbFilePath：载入与停止抓包两条路径共用的收尾。
+    // 解析 pcapFilePath 入库到 dbFilePath：载入与停止抓包两条路径共用的收尾。
     bool analyzeAndStore(const std::string& pcapFilePath, const std::string& dbFilePath);
 
     std::string tsharkPath_;
@@ -103,12 +107,20 @@ private:
     PdmlToJsonConverter          converter_;
     std::unique_ptr<SQLiteUtil>  db_;
     std::unique_ptr<LiveCapture> capture_;
+    std::unique_ptr<NativeCapture> nativeCapture_; // 自研抓包（tshark 不可用时）
     std::unique_ptr<FlowMonitor> flow_;
-    bool                         capturing_ = false;
+    std::atomic<bool>            capturing_{false}; // 跨线程读写（UI 轮询 / 后台停止）安全
 
-    // 保护 packets_ 的快照读写
-    mutable std::mutex                   mutex_;
-    std::vector<std::shared_ptr<Packet>> packets_;
+    // 后端选择：true = 自研引擎（无 tshark），false = tshark。
+    // nativeAnalyzer_ 仅在 native_ 时使用；与 analyzer_ 同受 analyzerMutex_ 保护。
+    bool                           native_ = false;
+    std::unique_ptr<NativeAnalyzer> nativeAnalyzer_;
+
+    // 保护 packets_ 快照（原子交换的 shared_ptr，读写双方均持锁拷贝引用计数）
+    mutable std::mutex                                                       mutex_;
+    std::shared_ptr<const std::vector<std::shared_ptr<Packet>>>              packets_;
+    // 保护 analyzer_ 内部状态：后台写入与 UI 线程读取互斥。锁序 analyzerMutex_ → mutex_，不得反序。
+    mutable std::mutex analyzerMutex_;
 };
 
 #endif

--- a/include/FlowMonitor.hpp
+++ b/include/FlowMonitor.hpp
@@ -27,8 +27,7 @@ public:
     std::shared_ptr<std::thread> monitorThread;
     FILE*                        monitorTsharkPipe;
     ProcessUtil::ProcHandle      tsharkPid;
-    // 单次 read 可能只读到半行、也可能一次读到多行；用它跨 read 暂存未完成的行尾，
-    // 凑齐一个 '\n' 再解析，避免丢弃同一 read 里的后续行（旧实现只解析第一行）。
+    // 跨 read 暂存未完成的行尾，凑齐 '\n' 再解析，避免丢弃同一 read 里的后续行。
     std::string readLeftover;
 };
 
@@ -60,17 +59,14 @@ private:
 
     std::map<std::string, AdapterMonitorInfo> adapterFlowTrendMonitorMap;
 
-    // fd → 对应网卡监控状态的直接索引：轮询返回就绪 fd 后 O(1) 反查，
-    // 取代对 adapterFlowTrendMonitorMap 的线性扫描（fileno==pipeFd）。
-    // 值为指向 map 内元素的裸指针——std::map 是 node-based，元素地址在
-    // 插入/删除其它键时保持稳定，故指针不会失效。
+    // fd → 网卡监控状态的 O(1) 反查索引，取代对 map 的线性扫描。
+    // 值为指向 map 内元素的裸指针——std::map node-based，元素地址插删其它键时稳定，指针不失效。
     std::unordered_map<int, AdapterMonitorInfo*> fdToAdapter;
 
     std::recursive_mutex adapterFlowTrendMapLock;
     long                 adapterFlowTrendMonitorStartTime;
 
-    // 监控工作线程与其停止标志：线程 joinable，stop 时先置停止标志再 join，
-    // 确保销毁监控 map 前线程已退出，消除线程读裸指针的竞态。
+    // 监控工作线程与停止标志：stop 时先置标志再 join，确保销毁 map 前线程已退出，消除读裸指针竞态。
     std::thread       flowTrendThread;
     std::atomic<bool> stopFlag;
 };

--- a/include/LiveCapture.hpp
+++ b/include/LiveCapture.hpp
@@ -10,13 +10,10 @@
 #include "processUtil.hpp" // ProcessUtil::ProcHandle（跨平台进程句柄）
 #include "tsharkDataType.hpp"
 
-// 实时抓包：在指定网卡上启动 tshark，一边把原始报文写入 pcap 文件（-w），一边用
-// -T fields 把每个包的关键字段实时打到 stdout（-l 行缓冲、-P 即便写文件也打印）。
-// 工作线程逐行解析成 Packet，并通过回调把每个包**实时**交给调用方（UI），实现边抓边显示。
-//
-// 停止语义：tshark 是往 -w 文件写、几乎不写 stdout，只关管道它不会退出，必须给它发信号
-// 令其收尾（flush 文件 + 关 stdout），读循环随之得到 EOF 优雅结束。stopCapture 只负责
-// 发信号 + join，由工作线程内的 PcloseEx 统一 waitpid 回收，避免双重回收。可安全重复调用。
+// 实时抓包：启动 tshark 把原始报文写入 pcap（-w），同时用 -T fields 把关键字段实时打到 stdout。
+// 工作线程逐行解析成 Packet，通过回调实时交给调用方，实现边抓边显示。
+// 停止语义：tshark 只关管道不会退出，必须发信号令其收尾，读循环随之 EOF。
+// stopCapture 只负责发信号 + join，由工作线程内的 PcloseEx 统一回收，避免双重回收；可安全重复调用。
 class LiveCapture
 {
 public:
@@ -30,23 +27,27 @@ public:
     std::string getTsharkPath() const { return tsharkPath_; }
     void        setTsharkPath(const std::string& path) { tsharkPath_ = path; }
 
-    // 开始抓包。onPacket 可为空（仅落盘不实时回调）。captureFile 为落盘 pcap 路径。
+    // 开始抓包。onPacket 可为空（仅落盘）。captureFile 为落盘路径。
+    // durationSeconds > 0 时加 -a duration:N 到时自动停止；0 表示不限时（手动 stopCapture）。
     bool startCapture(const std::string& adapterName, PacketCallback onPacket = nullptr,
-                      const std::string& captureFile = "capture.pcap");
+                      const std::string& captureFile = "capture.pcap",
+                      int durationSeconds = 0);
 
     // 停止抓包：发 SIGTERM 令 tshark 收尾，join 工作线程。幂等，可安全重复调用。
     bool stopCapture();
 
-    bool isCapturing() const { return captureWorkThread_ != nullptr; }
+    bool isCapturing() const { return running_.load(); }
 
 private:
     void captureWorkThreadEntry(std::string adapterName, std::string captureFile,
-                                PacketCallback onPacket);
+                                PacketCallback onPacket, int durationSeconds);
 
 private:
     std::string                  tsharkPath_;
     std::string                  ip2RegionDbPath_;
     std::atomic<bool>            stopFlag_;
+    std::atomic<bool>            running_; // 抓包工作线程活跃标志（线程自然退出后为 false，
+                                           // 供 isCapturing 区分“线程对象存在”与“真在抓包”）
     std::atomic<bool>            startFailed_; // 工作线程启动 tshark 失败时置位，供 startCapture 回传
     std::atomic<ProcessUtil::ProcHandle> tsharkPid_; // 供 stopCapture 发信号；kInvalidProc 表示未就位
     std::shared_ptr<std::thread> captureWorkThread_;

--- a/include/NativeAnalyzer.hpp
+++ b/include/NativeAnalyzer.hpp
@@ -1,0 +1,44 @@
+#ifndef NativeAnalyzer_hpp
+#define NativeAnalyzer_hpp
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "PcapFileReader.hpp"
+#include "tsharkDataType.hpp"
+
+// 自研离线分析引擎：直接解析 pcap / pcapng 文件（无需 tshark）。
+// 与 PcapAnalyzer 职责平行，供无 tshark 环境兜底：
+//   - analyzeFile：遍历文件记录，逐包经 NativePacketParser 解析成 Packet 向量
+//     （file_offset 指向 packet-data 起始，hex 可随机读）
+//   - getPacketHexData / getPacketDetailTree / getFramesByDisplayFilter
+// 线程约定：与 PcapAnalyzer 一致，由调用方（AnalysisSession 的 analyzerMutex_）串行化。
+class NativeAnalyzer
+{
+public:
+    NativeAnalyzer() = default;
+
+    // 解析 pcap/pcapng 文件（自动识别格式）。out 回填全部报文。
+    bool analyzeFile(const std::string& filePath, std::vector<std::shared_ptr<Packet>>& out);
+
+    bool getPacketHexData(uint32_t frameNumber, std::vector<unsigned char>& out) const;
+    bool getPacketDetailTree(uint32_t frameNumber, DetailNode& root) const;
+    // 自研显示过滤子集；不支持的表达式经 err 返回原因。
+    bool getFramesByDisplayFilter(const std::string& expr, std::vector<uint32_t>& frames,
+                                  std::string* err = nullptr) const;
+
+    bool isOpen() const { return reader_.isOpen(); }
+    const std::string& currentPath() const { return currentPath_; }
+
+private:
+    PcapFileReader reader_;
+    std::string    currentPath_;
+    // 全部报文；读 hex / 详情树的字节偏移与长度直接取自 Packet 的 file_offset / cap_len，不另存平行数组。
+    std::vector<std::shared_ptr<Packet>> packets_;
+    // 文件链路层类型（供 getPacketDetailTree 正确重解析：Ethernet/NULL/SLL 等）。
+    int  linkType_ = 1;
+    bool analyzed_ = false;
+};
+
+#endif

--- a/include/NativeCapture.hpp
+++ b/include/NativeCapture.hpp
@@ -1,0 +1,41 @@
+#ifndef NativeCapture_hpp
+#define NativeCapture_hpp
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "tsharkDataType.hpp"
+
+// 自研实时抓包引擎：基于 libpcap，与 LiveCapture 职责平行，供无 tshark 环境兜底。
+// 抓包线程 pcap_next_ex 逐包解析后回调，并按经典 pcap 格式落盘（停止后可离线解析）。
+// 线程模型：回调在抓包线程执行，调用方自行加锁。
+// 无 libpcap 编译（EASYTSHARK_HAVE_LIBPCAP 未定义）时：listAdapters 返回空、startCapture 返回 false。
+class NativeCapture
+{
+public:
+    using PacketCallback = std::function<void(const std::shared_ptr<Packet>&)>;
+
+    NativeCapture();
+    ~NativeCapture();
+
+    bool startCapture(const std::string& adapterName, PacketCallback onPacket,
+                      const std::string& captureFile, int durationSeconds = 0);
+    bool stopCapture();
+    bool isCapturing() const { return running_.load(); }
+
+    // 网卡枚举（libpcap 实现）；无 libpcap 时返回空。
+    static std::vector<AdapterInfo> listAdapters();
+
+private:
+    void workThread(std::string adapterName, PacketCallback onPacket,
+                    std::string captureFile, int durationSeconds);
+
+    std::atomic<bool> stopFlag_{false};
+    std::atomic<bool> running_{false};
+    std::shared_ptr<std::thread> thread_;
+};
+
+#endif

--- a/include/NativePacketParser.hpp
+++ b/include/NativePacketParser.hpp
@@ -1,0 +1,76 @@
+#ifndef NativePacketParser_hpp
+#define NativePacketParser_hpp
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "tsharkDataType.hpp"
+
+// 自研协议解析引擎：原始帧字节 → 与 tshark -T fields 对齐的 Packet。供无 tshark 环境兜底。
+// 覆盖 Ethernet(VLAN/QinQ) / ARP / IPv4 / IPv6 / ICMP / ICMPv6(ND) / TCP / UDP，
+// 应用层 DNS / HTTP / TLS(SNI) / DHCP / NTP / SSH 等；只覆盖展示所需字段，不做完整协议语义。
+namespace NativePacketParser
+{
+// 应用层协议详情（供完整协议树与增强 info 使用）。
+struct ProtocolDetail
+{
+    // HTTP
+    bool        http = false;
+    std::string httpMethod;  // GET/POST/...
+    std::string httpUri;     // /path?query
+    std::string httpVersion; // HTTP/1.1
+    std::string httpStatus;  // "200"
+    std::string httpReason;  // "OK"
+    std::string httpHost;    // Host header
+    // TLS
+    bool        tls = false;
+    std::string tlsType;    // "Client Hello" / "Server Hello" / "Certificate" ...
+    std::string tlsVersion; // "TLS 1.2" ...
+    std::string tlsSni;     // SNI 扩展里的服务器名
+    // DNS 响应回答摘要（"A 93.184.216.34, AAAA 2606:... "）
+    std::string dnsAnswers;
+    // DHCP
+    bool        dhcp = false;
+    std::string dhcpType; // Discover / Offer / Request / Ack ...
+    // NTP
+    bool        ntp = false;
+    std::string ntpDesc;
+    // IP 分片
+    bool     ipFragmented = false;
+    uint16_t fragOffset   = 0;
+    bool     fragMore     = false;
+};
+
+// 解析一个原始帧，填充 packet。成功返回 true；帧太短/格式异常返回 false（不抛异常、不崩溃）。
+// linkType：0 = NULL/Loopback（BSD lo，前 4 字节地址族），1 = Ethernet，-1 = 自动检测。
+bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType = -1);
+
+// 完整协议树：从原始帧重建（含应用层分层：HTTP/TLS/DNS/DHCP 子层、IP 分片标记）。
+// root 需预先为 DetailNode()（调用方负责）。
+bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint32_t frameNumber,
+                     DetailNode& root);
+
+// 判断显示过滤表达式是否命中一个报文（自研子集）。
+// 支持的字段：
+//   frame.number（整数）
+//   eth.addr / eth.src / eth.dst（MAC）
+//   ip.addr / ip.src / ip.dst / ipv6.addr / ipv6.src / ipv6.dst（IP）
+//   tcp.port / tcp.srcport / tcp.dstport / udp.port / udp.srcport / udp.dstport（整数）
+//   协议存在性：tcp udp arp icmp icmpv6 dns http tls ssl ssh dhcp ntp（无操作数）
+// 操作符：== !=   逻辑：&& || !   支持括号。
+// 返回 true 表示表达式合法且命中；expr 非法时置 *err 并返回 false。
+bool matchDisplayFilter(const std::string& expr, const Packet& packet,
+                        std::string* err = nullptr);
+
+// 把显示过滤表达式「编译一次」为可复用谓词，用于对大量报文反复求值（避免每包重新解析）。
+// 表达式非法时置 *err 并返回空 function（转 bool 为 false）。
+std::function<bool(const Packet&)> compileDisplayFilter(const std::string& expr,
+                                                        std::string* err = nullptr);
+
+// 判断当前是否在无 tshark 环境下也能解析（恒 true——本引擎不依赖外部程序）。
+bool available();
+} // namespace NativePacketParser
+
+#endif

--- a/include/PacketParser.hpp
+++ b/include/PacketParser.hpp
@@ -5,8 +5,7 @@
 
 #include "tsharkDataType.hpp"
 
-// 纯粹的行解析：把一行 tshark "-T fields" 制表符分隔输出解析成 Packet。
-// 不依赖 tshark 进程、不做任何 IO、不查询 IP 地理位置——因此可脱离 tshark 独立单测。
+// 纯行解析：把一行 tshark "-T fields" 制表符分隔输出解析成 Packet；无 IO、可独立单测。
 // 字段顺序与 TsharkCommand::tsharkFieldArgs() 严格对应（0..15），改动需两处同步。
 namespace PacketParser
 {

--- a/include/PcapAnalyzer.hpp
+++ b/include/PcapAnalyzer.hpp
@@ -9,9 +9,8 @@
 #include "PcapFileReader.hpp"
 #include "tsharkDataType.hpp"
 
-// 离线解析：读取 pcap 文件，逐行解析 tshark 字段输出为 Packet，并提供
-// 报文列表 / 十六进制原始数据的访问。只负责“解析与就地存取”，不涉及抓包、
-// 数据库入库或格式转换（那些是 LiveCapture / main 的 SQLiteUtil / PdmlToJsonConverter 的职责）。
+// 离线解析：读 pcap 文件，逐行解析 tshark 字段输出为 Packet，提供报文列表 / 原始
+// 十六进制访问。只负责“解析与就地存取”，不涉及抓包、入库或格式转换。
 class PcapAnalyzer
 {
 public:
@@ -46,11 +45,12 @@ public:
     // 只取帧号、不重算 file_offset，故配合已加载报文的既有 offset 可保持 hex 正确。
     // filter 为空视为“全部匹配”返回 false（调用方应据此走不过滤路径）。
     bool getFramesByDisplayFilter(const std::string&     displayFilter,
-                                  std::vector<uint32_t>& frameNumbers);
+                                  std::vector<uint32_t>& frameNumbers,
+                                  std::string* errorOut = nullptr);
 
 private:
-    // 逐包解析核心：跑 tshark 读文件、算 file_offset、补地理位置，每解析出一个
-    // Packet 就回调 onPacket。本身不累积——由调用方决定“累积”还是“流式丢弃”。
+    // 逐包解析核心：跑 tshark、算 file_offset、补地理位置，逐包回调 onPacket。
+    // 本身不累积——由调用方决定“累积”还是“流式丢弃”。
     bool streamPackets(const std::string&                                       filePath,
                        const std::function<void(const std::shared_ptr<Packet>&)>& onPacket);
 
@@ -66,9 +66,8 @@ private:
     // 避免每次取包都重新 open/close 文件（POSIX 走 mmap，非 POSIX 走 ifstream）。
     PcapFileReader fileReader;
 
-    // tshark 的 frame_number 从 1 起、稠密递增，故用 vector 按 (帧号-1) 下标直存：
-    // 相比 unordered_map 省去每包一次哈希桶节点分配与哈希/取模，遍历也变成对连续内存的
-    // 顺序扫描，对 CPU cache 与预取器都更友好。理论上若出现空洞，对应槽为空指针。
+    // frame_number 从 1 起稠密递增，故用 vector 按 (帧号-1) 下标直存（免哈希、cache 友好）；
+    // 若出现空洞，对应槽为空指针。
     std::vector<std::shared_ptr<Packet>> allPackets;
 };
 

--- a/include/PcapFileReader.hpp
+++ b/include/PcapFileReader.hpp
@@ -7,17 +7,10 @@
 #include <vector>
 
 // 按文件偏移随机读取 pcap 报文数据的小抽象：一次打开、多次随机读，
-// 消除“每次取包都重新 open/close 文件”的系统调用开销。
-//
-// 两套实现按平台选择编译（见 PcapFileReader.cpp）：
-//   - POSIX（Linux/macOS）：mmap 整个文件，readAt 从映射区 memcpy。
-//     随机按 offset 访问免去 lseek+read 双系统调用与一次内核→用户拷贝，
-//     靠缺页中断按需调页。
-//   - 非 POSIX（含 Windows，暂以文件流兜底）：持有 std::ifstream，
-//     readAt 用 clear()+seekg+read；相比原实现仍省去重复 open/close。
-//
-// 非拷贝语义：持有独占的文件资源（映射/句柄/流），禁用拷贝，允许移动语义
-// 由使用方避免（这里直接删除拷贝，作为 PcapAnalyzer 的成员按需 open 即可）。
+// 消除“每次取包都重新 open/close 文件”的开销。两套实现按平台编译：
+//   - POSIX（Linux/macOS）：mmap 整个文件，readAt 从映射区 memcpy，免 lseek+read。
+//   - 非 POSIX（含 Windows，暂以文件流兜底）：std::ifstream + seekg/read。
+// 持有独占文件资源，故禁用拷贝。
 class PcapFileReader
 {
 public:
@@ -27,13 +20,22 @@ public:
     // 打开文件（会先关闭之前打开的）。成功返回 true。
     bool open(const std::string& path);
 
-    // 从 offset 读取 len 字节到 out。越界 / 未打开 / 读取失败返回 false。
+    // 从 offset 读取 len 字节到 out（拷贝，供调用方长期持有）。越界/未打开/失败返回 false。
     bool readAt(uint64_t offset, uint32_t len, std::vector<unsigned char>& out) const;
+
+    // 零拷贝借出只读指针，越界/未打开返回 nullptr。用于批量顺序遍历的热路径。
+    // 契约：返回指针仅在本 reader 下一次 viewAt/readAt/close 之前有效。
+    //   - POSIX：直接指向 mmap 映射区，全程稳定。
+    //   - 非 POSIX：指向内部复用缓冲，下次调用即失效。
+    const unsigned char* viewAt(uint64_t offset, uint32_t len) const;
 
     // 释放底层资源（析构会自动调用）
     void close();
 
     bool isOpen() const;
+
+    // 文件大小（字节）；未打开时 0。供调用方判断遍历边界，避免试探性越界读。
+    uint64_t size() const { return size_; }
 
 private:
     // 禁止拷贝：底层持有 mmap 映射或文件句柄，拷贝会造成双重释放
@@ -41,9 +43,11 @@ private:
     PcapFileReader& operator=(const PcapFileReader&);
 
 #if defined(_WIN32)
-    // 兜底实现：标准库文件流（Windows 尚未使用原生 CreateFileMapping 内存映射）
+    // 兜底实现：标准库文件流（Windows 尚未用原生 CreateFileMapping）
     mutable std::ifstream stream_;
     uint64_t              size_;
+    // viewAt 的复用缓冲：下次 viewAt/readAt 会覆盖它（见头注释契约）。
+    mutable std::vector<unsigned char> viewBuf_;
 #else
     // POSIX：mmap 映射
     int         fd_;

--- a/include/platform/EventPoller.hpp
+++ b/include/platform/EventPoller.hpp
@@ -6,13 +6,8 @@
 #include <vector>
 
 // 事件轮询抽象：屏蔽不同平台的 I/O 多路复用机制。
-//
-// 背景：项目最初在 Linux 上用 epoll 实现，但 epoll 是 Linux 专有的，
-// macOS/BSD 没有。这里改用 POSIX 标准的 poll()——语义与 epoll 一一对应，
-// 且 Linux 与 macOS 可以共用同一份实现（见 src/platform/EventPollerPoll.cpp）。
-//
-// 设计要点：头文件不引入 <poll.h>，成员只保存原始 fd，具体的 pollfd
-// 数组在 .cpp 内临时构造，从而让业务代码（FlowMonitor）完全不感知底层机制。
+// 用 POSIX 标准 poll()（Linux/macOS 共用，见 EventPollerPoll.cpp），Windows 另有实现。
+// 头文件不引入 <poll.h>，成员只存原始 fd，pollfd 数组在 .cpp 内临时构造。
 class EventPoller
 {
 public:
@@ -29,15 +24,10 @@ public:
 
     std::size_t size() const;
 
-    // 等待事件，最多阻塞 timeoutMs 毫秒（-1 表示无限等待，0 表示立即返回）。
-    // 返回本次变为可读的 fd 列表；超时则返回空 vector。
-    // 对端关闭（POLLHUP）或出错（POLLERR）也会并入返回，
-    // 由调用方通过 read() 得到 EOF 或错误码后自行处理。
-    //
-    // 线程安全：本类的所有方法都可跨线程调用（原 epoll 允许在一个线程
-    // epoll_wait 的同时另一线程 epoll_ctl，这里保持同样语义）。实现上
-    // wait() 在持锁时拷贝 fd 快照后即释放锁再执行 poll()，因此一次阻塞的
-    // wait 不会挡住另一线程的 add/remove。
+    // 等待事件，最多阻塞 timeoutMs 毫秒（-1 无限等待，0 立即返回）。返回本次可读的 fd 列表，
+    // 超时则为空。对端关闭（POLLHUP）/出错（POLLERR）也并入，由调用方 read() 后自行处理。
+    // 线程安全：所有方法可跨线程调用；wait() 持锁拷贝 fd 快照后即释放锁再 poll()，
+    // 故阻塞的 wait 不挡住其它线程的 add/remove。
     std::vector<int> wait(int timeoutMs);
 
 private:

--- a/include/platform/PipeIO.hpp
+++ b/include/platform/PipeIO.hpp
@@ -3,12 +3,8 @@
 
 #include <cstddef>
 
-// 管道非阻塞读取的跨平台小抽象。
-//
-// 背景：FlowMonitor 为每块网卡开一个 tshark 子进程，用 EventPoller 汇聚可读事件后，
-// 需要以“有多少读多少、绝不阻塞”的方式把数据抽干。POSIX 用 fcntl(O_NONBLOCK)+read，
-// Windows 匿名管道不支持 fd 级非阻塞，需先 PeekNamedPipe 探测再 ReadFile。此处把这点
-// 差异收敛到两个函数里，业务代码（FlowMonitor）保持平台无关。
+// 管道非阻塞读取的跨平台小抽象：把“有多少读多少、绝不阻塞”的平台差异收敛到两个函数。
+// POSIX 用 fcntl(O_NONBLOCK)+read；Windows 匿名管道不支持 fd 级非阻塞，先 PeekNamedPipe 再 ReadFile。
 namespace platform
 {
 // 把源自 popen 管道的 CRT fd 设为非阻塞。

--- a/include/processUtil.hpp
+++ b/include/processUtil.hpp
@@ -15,12 +15,10 @@
 class ProcessUtil {
 public:
 #if defined(_WIN32)
-    // Windows：子进程由内核对象 HANDLE 标识（等待/终止都需要它）。头文件里用
-    // void* 承载，避免把重型的 <windows.h> 传染给所有包含者；实现里再转回 HANDLE。
+    // Windows：子进程用 HANDLE 标识。头文件用 void* 承载，避免把 <windows.h> 传染给包含者。
     using ProcHandle = void*;
 #else
-    // POSIX：子进程由 pid_t 标识。此别名令 ProcHandle 在 POSIX 上等价于 pid_t，
-    // 故现有以 pid_t 传参/存储的调用方无需改动即可继续编译。
+    // POSIX：子进程用 pid_t 标识。
     using ProcHandle = pid_t;
 #endif
 
@@ -61,7 +59,7 @@ public:
      * @return FILE* 管道文件指针，失败返回 nullptr
      */
     static FILE* PopenEx(const std::vector<std::string>& argv, ProcHandle* pid,
-                         const char* type = "r");
+                         const char* type = "r", bool mergeStderr = false);
 
     /**
      * @brief 终止指定子进程并回收
@@ -73,9 +71,8 @@ public:
     /**
      * @brief 请求子进程终止，但**不回收**（不 waitpid / 不 CloseHandle）
      * @param pid 子进程句柄
-     * @note 供“发信号令其收尾 + 由配套 PcloseEx 单点回收”的场景（如 LiveCapture 停止）使用，
-     *       避免与 PcloseEx 争抢回收造成 POSIX 双重 waitpid 或 Windows 双重 CloseHandle。
-     *       POSIX 发 SIGTERM；Windows 用 TerminateProcess（不关句柄）。
+     * @note 供“发信号收尾 + 由配套 PcloseEx 单点回收”的场景使用，避免与 PcloseEx 争抢回收
+     *       造成双重 waitpid / CloseHandle。POSIX 发 SIGTERM；Windows 用 TerminateProcess。
      */
     static bool Signal(ProcHandle pid);
 

--- a/include/tsharkCommand.hpp
+++ b/include/tsharkCommand.hpp
@@ -7,21 +7,16 @@
 #include "tsharkDataType.hpp"
 
 // 低层 tshark 交互工具：平台默认路径、命令参数构造、网卡枚举。
-// 各职责类（PcapAnalyzer / LiveCapture / FlowMonitor / PdmlToJsonConverter）
-// 依赖此处的自由函数，此处不反向依赖任何职责类——保持依赖单向。
+// 依赖单向：各职责类依赖此处的自由函数，此处不反向依赖任何职责类。
 namespace TsharkCommand
 {
-// tshark / editcap 的平台默认路径（单一真源）：
-//   Linux 装在 /usr/bin，macOS 由 Wireshark.app 提供，Windows 装在 Program Files。
-// 如与实际安装位置不符，调用方可自行覆盖传入的路径。
+// tshark / editcap 的平台默认路径（单一真源）：Linux /usr/bin、macOS Wireshark.app、
+// Windows Program Files。与实际安装位置不符时调用方可自行覆盖。
 std::string defaultTsharkPath();
 std::string defaultEditcapPath();
 
-// 自动定位 tshark：按 环境变量 EASYTSHARK_TSHARK → 平台默认路径 → PATH →
-// (Windows)注册表 Wireshark InstallDir → 常见安装目录 的顺序，返回首个真实存在的路径；
-// 全都没命中时回退到平台默认路径（让后续报错仍指向一个合理位置）。
-// 目标：装了就能用；装在非默认位置也可用环境变量手动指定，无需重新编译。
-// 平台差异（PATH 分隔符 / .exe 后缀 / 注册表）都封装在实现里，POSIX 行为不受影响。
+// 自动定位 tshark，按序返回首个真实存在的路径，全未命中则回退平台默认路径：
+//   环境变量 EASYTSHARK_TSHARK → 平台默认 → PATH → (Windows)注册表 → 常见安装目录。
 std::string resolveTsharkPath();
 
 // 自动定位 editcap：优先取"解析到的 tshark 同目录"下的 editcap（保证版本/位置一致），

--- a/include/tsharkDataType.hpp
+++ b/include/tsharkDataType.hpp
@@ -25,14 +25,11 @@ struct Packet
     std::string info;
     // 该报文在 pcap 文件中的字节偏移。累计值可超过 4GB，用 64 位避免大文件溢出。
     uint64_t file_offset = 0;
-    // 传输层协议（"TCP"/"UDP"/""）：仅内存态、不入库，由 parseLine 依据
-    // tcp/udp 端口字段哪个非空推断，供 GUI 的会话视图区分 TCP / UDP 会话。
+    // 传输层协议（"TCP"/"UDP"/""）：仅内存态、不入库，供 GUI 会话视图区分 TCP/UDP。
     std::string transport;
 };
 
-// 协议分层树的一个节点：把 tshark PDML 的 proto / field 逐层解析成
-// label（显示名）+ value（取值）+ children（子字段），供详情面板递归展开。
-// 只承载展示用文本，不做协议语义解释。
+// 协议分层树节点：承载展示用文本（label/value/children），供详情面板递归展开。
 struct DetailNode
 {
     std::string             label; // 显示名（PDML showname，回退到 name）

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -39,15 +39,15 @@ public:
      */
     static std::string get_timestamp();
 
+    // 清理 dir 下日志：按修改时间保留最近 keep 个（*.log），删除更旧的，防止无限累积。
+    static void pruneLogFiles(const std::string& dir, size_t keep);
+
     static void translateShowNameFields(rapidjson::Value&                   value,
                                         rapidjson::Document::AllocatorType& allocator);
 
     /**
      * @brief 把一批报文序列化为 JSON 字符串（{"total":N,"packets":[...]}）
-     *
-     * 从 SQLiteUtil 的查询序列化中抽出，供多个前端复用：查询结果（CLI/GUI）与
-     * Web 层的 /api/packets 都用同一份字段约定，避免重复实现导致口径漂移。
-     * 只读取 packets（内部用 StringRef 引用其字符串内存），序列化期间入参须存活。
+     * @note 内部用 StringRef 引用 packets 的字符串内存，序列化期间入参须保持存活。
      */
     static std::string packetsToJson(const std::vector<std::shared_ptr<Packet>>& packets);
 };
@@ -75,8 +75,7 @@ public:
      * @param limit 最多返回的行数；<0 表示不分页、返回全部（默认，保持旧行为）
      * @param offset 跳过的行数，仅在 limit>=0 时生效
      *
-     * @note limit>=0 时按 frame_number 升序返回，保证翻页结果稳定；
-     *       大抓包下用分页可避免一次性把全表读进内存造成内存尖峰。
+     * @note limit>=0 时按 frame_number 升序返回，保证翻页稳定；分页避免全表读入的内存尖峰。
      */
     bool queryPacket(std::vector<std::shared_ptr<Packet>>& packetList, int limit = -1,
                      int offset = 0);
@@ -92,12 +91,7 @@ public:
 private:
     sqlite3* db = nullptr;
 
-    /**
-     * @brief 参数化查询中的一个绑定值
-     *
-     * SQL 语句中用 `?` 占位，实际值放在这里，执行时通过 sqlite3_bind_* 绑定，
-     * 从根本上避免把用户输入拼进 SQL 文本造成注入。
-     */
+    // 参数化查询的绑定值：SQL 用 `?` 占位、值经 sqlite3_bind_* 绑定，避免拼接注入。
     struct BindParam
     {
         enum Type

--- a/include/web/WebServer.hpp
+++ b/include/web/WebServer.hpp
@@ -1,0 +1,20 @@
+#ifndef EasyTshark_WebServer_hpp
+#define EasyTshark_WebServer_hpp
+
+#include <string>
+
+#include "httplib/httplib.h"
+
+#include "AnalysisSession.hpp"
+
+// Web 前端的 HTTP 路由层：把 /api/* 路由、令牌鉴权、Origin 校验、路径白名单集中于此，
+// 供生产入口（main_web.cpp）与单元测试复用，不绑定命令行参数。
+//
+// 线程：httplib 每连接一线程，处理器可能并发进入；内部用 opMutex 串行化写操作，
+// 实时抓包回调只推进带锁的 liveBuffer。
+// 安全：所有 /api/* 须带 X-Auth-Token；浏览器请求还校验 Origin==Host；
+// /api/load 仅允许用户主目录或 data/ 下的文件。静态资源不要求 token。
+void registerWebRoutes(httplib::Server& svr, AnalysisSession& session,
+                       const std::string& token);
+
+#endif

--- a/src/AnalysisSession.cpp
+++ b/src/AnalysisSession.cpp
@@ -10,19 +10,20 @@
 #include <direct.h> // _mkdir
 #endif
 
+#include "NativeAnalyzer.hpp"
+#include "NativeCapture.hpp"
 #include "loguru/loguru.hpp"
 #include "tsharkCommand.hpp"
 
 namespace
 {
-// 以下文件操作全部走程序内逻辑，不再拼接命令交给 /bin/sh 执行，
-// 从根本上消除路径中的 shell 元字符（; | $() 等）被解释的注入风险。
+// 文件操作全部走程序内逻辑，不拼接 shell 命令，避免路径中的 shell 元字符注入。
 
 // 创建单层目录，已存在也视为成功
 bool ensureDir(const std::string& dir)
 {
 #if defined(_WIN32)
-    // Windows 无 POSIX mkdir 的权限位参数；_mkdir 仅接受路径。
+    // Windows 的 _mkdir 无权限位参数，仅接受路径。
     if (_mkdir(dir.c_str()) == 0)
     {
         return true;
@@ -34,6 +35,29 @@ bool ensureDir(const std::string& dir)
     }
 #endif
     return errno == EEXIST;
+}
+
+// 递归创建 filePath 的父目录（类似 mkdir -p），最后一段视为文件名不创建。
+bool ensureParentDir(const std::string& filePath)
+{
+    size_t slash = filePath.find_last_of("/\\");
+    if (slash == std::string::npos || slash == 0)
+        return true; // 无目录部分，或形如 "/name"（根下）——无需创建
+    // 依次创建路径上每个中间前缀（跳过盘符根 "C:" 与空段）
+    for (size_t i = 1; i < slash; ++i)
+    {
+        if (filePath[i] != '/' && filePath[i] != '\\')
+            continue;
+        std::string sub = filePath.substr(0, i);
+        if (sub.empty() || (sub.size() == 2 && sub[1] == ':'))
+            continue;
+        if (!ensureDir(sub))
+            return false;
+    }
+    std::string parent = filePath.substr(0, slash);
+    if (parent.size() == 2 && parent[1] == ':')
+        return true; // 形如 "C:foo" 的盘符相对路径，父目录即盘符根，无需创建
+    return ensureDir(parent);
 }
 
 bool copyFile(const std::string& src, const std::string& dst)
@@ -66,13 +90,22 @@ AnalysisSession::AnalysisSession(const std::string& tsharkPath, const std::strin
       dataDir_(dataDir),
       pcapsDir_(dataDir + "/pcaps"),
       analyzer_(tsharkPath),
-      converter_(tsharkPath)
+      converter_(tsharkPath),
+      // 初始为空快照（非 null）：调用方无需检查空指针即可安全解引用。
+      packets_(std::make_shared<const std::vector<std::shared_ptr<Packet>>>()),
+      // 后端选择：tshark 不可用时降级到自研引擎（libpcap + 内置解析），否则优先用 tshark。
+      native_(!TsharkCommand::tsharkAvailable(tsharkPath))
 {
+    if (native_)
+    {
+        LOG_F(INFO, "未检测到 tshark：启用自研引擎（离线解析/实时抓包/详情树/过滤子集）");
+        nativeAnalyzer_.reset(new NativeAnalyzer());
+    }
     if (!ensureDir(dataDir_))
     {
         LOG_F(WARNING, "创建数据目录失败: %s", dataDir_.c_str());
     }
-    // 抓包/载入的 pcap 与 db 按时间戳留存于此子目录，历史全部保留、不覆盖。
+    // pcap 与 db 按时间戳留存于此子目录，历史不覆盖。
     if (!ensureDir(pcapsDir_))
     {
         LOG_F(WARNING, "创建 pcap 目录失败: %s", pcapsDir_.c_str());
@@ -84,9 +117,28 @@ AnalysisSession::~AnalysisSession() = default;
 
 void AnalysisSession::setTsharkPath(const std::string& path)
 {
+    // 切换后端必须持 analyzerMutex_：否则后台任务正用 nativeAnalyzer_ 时 reset() 会 use-after-free。
+    // 锁序 analyzerMutex_ → mutex_，此处只取前者。
+    std::lock_guard<std::mutex> alock(analyzerMutex_);
     tsharkPath_ = path;
     analyzer_.setTsharkPath(path);
     converter_.setTsharkPath(path);
+    // 重新评估后端：新路径有效则回到 tshark，否则继续自研引擎。
+    bool nowNative = !TsharkCommand::tsharkAvailable(path);
+    if (native_ != nowNative)
+    {
+        native_ = nowNative;
+        if (native_)
+        {
+            if (!nativeAnalyzer_)
+                nativeAnalyzer_.reset(new NativeAnalyzer());
+        }
+        else
+        {
+            nativeAnalyzer_.reset(); // 不再需要：切回 tshark 引擎
+        }
+        LOG_F(INFO, "后端切换为 %s", native_ ? "自研引擎" : "tshark");
+    }
     // capture_/flow_ 每次操作按 tsharkPath_ 新建，无需在此同步已存在实例。
 }
 
@@ -98,7 +150,7 @@ bool AnalysisSession::loadPcap(const std::string& srcPath)
         return false;
     }
 
-    // 每次载入按时间戳留一份到 pcaps 目录，历史不覆盖；db 与之一一对应。
+    // 按时间戳留一份到 pcaps 目录，历史不覆盖；db 与之一一对应。
     std::string ts       = CommonUtil::get_timestamp();
     std::string destPcap = pcapsDir_ + "/capture_" + ts + ".pcap";
     std::string destDb   = pcapsDir_ + "/packets_" + ts + ".db";
@@ -119,13 +171,19 @@ bool AnalysisSession::analyzeAndStore(const std::string& pcapFilePath,
                                       const std::string& dbFilePath)
 {
     std::vector<std::shared_ptr<Packet>> packets;
-    if (!analyzer_.analysisFile(pcapFilePath, packets))
     {
-        LOG_F(ERROR, "解析 pcap 文件失败: %s", pcapFilePath.c_str());
-        return false;
+        // 解析期间锁住 analyzer_，避免 getHex/getDetailTree/queryDisplayFilter 读到半更新状态。
+        std::lock_guard<std::mutex> alock(analyzerMutex_);
+        bool ok = native_ ? nativeAnalyzer_->analyzeFile(pcapFilePath, packets)
+                          : analyzer_.analysisFile(pcapFilePath, packets);
+        if (!ok)
+        {
+            LOG_F(ERROR, "解析 pcap 文件失败: %s", pcapFilePath.c_str());
+            return false;
+        }
     }
 
-    // 入库：SQLiteUtil 构造失败会抛异常，这里就地捕获转为返回值，避免上抛到 UI 线程。
+    // SQLiteUtil 构造失败会抛异常，就地捕获转为返回值，避免上抛到 UI 线程。
     try
     {
         db_.reset(new SQLiteUtil(dbFilePath));
@@ -146,13 +204,14 @@ bool AnalysisSession::analyzeAndStore(const std::string& pcapFilePath,
         LOG_F(WARNING, "导入数据包到数据库失败");
     }
 
-    // analyzeAndStore 会在 UI 的后台线程（std::async）里执行，而 pcapPath()/savePcapAs
-    // 在 UI 线程读 currentPcapPath_，故路径成员与 packets_ 一并纳入 mutex_ 保护，消除竞态。
+    // 本函数跑在后台线程，路径成员与 packets_ 纳入 mutex_ 保护，供 UI 线程安全读取。
+    // 快照是 shared_ptr 原子交换：旧快照被持有者保活，调用方无需担心悬垂。
     {
         std::lock_guard<std::mutex> lock(mutex_);
         currentPcapPath_ = pcapFilePath;
         currentDbPath_   = dbFilePath;
-        packets_         = std::move(packets);
+        packets_         = std::make_shared<const std::vector<std::shared_ptr<Packet>>>(
+            std::move(packets));
     }
     return true;
 }
@@ -160,7 +219,7 @@ bool AnalysisSession::analyzeAndStore(const std::string& pcapFilePath,
 size_t AnalysisSession::packetCount() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    return packets_.size();
+    return packets_ ? packets_->size() : 0;
 }
 
 std::string AnalysisSession::pcapPath() const
@@ -169,36 +228,56 @@ std::string AnalysisSession::pcapPath() const
     return currentPcapPath_;
 }
 
-std::vector<std::shared_ptr<Packet>> AnalysisSession::packetsSnapshot() const
+std::shared_ptr<const std::vector<std::shared_ptr<Packet>>>
+AnalysisSession::packetsSnapshot() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    return packets_; // 拷贝 shared_ptr 向量，调用方拿到独立快照
+    return packets_; // 只拷贝引用计数，向量本体零拷贝；持有期间旧快照被保活
 }
 
 bool AnalysisSession::getHex(uint32_t frameNumber, std::vector<unsigned char>& out)
 {
-    return analyzer_.getPacketHexData(frameNumber, out);
+    std::lock_guard<std::mutex> alock(analyzerMutex_);
+    return native_ ? nativeAnalyzer_->getPacketHexData(frameNumber, out)
+                   : analyzer_.getPacketHexData(frameNumber, out);
 }
 
 bool AnalysisSession::getDetailTree(uint32_t frameNumber, DetailNode& root)
 {
-    return analyzer_.getPacketDetailTree(frameNumber, root);
+    std::lock_guard<std::mutex> alock(analyzerMutex_);
+    return native_ ? nativeAnalyzer_->getPacketDetailTree(frameNumber, root)
+                   : analyzer_.getPacketDetailTree(frameNumber, root);
 }
 
 bool AnalysisSession::queryDisplayFilter(const std::string&                    displayFilter,
-                                         std::vector<std::shared_ptr<Packet>>& out)
+                                         std::vector<std::shared_ptr<Packet>>& out,
+                                         std::string* errorOut)
 {
     out.clear();
     std::vector<uint32_t> frames;
-    if (!analyzer_.getFramesByDisplayFilter(displayFilter, frames))
+    {
+        // 与 analyzeAndStore 的解析互斥：读 analyzer_ 状态须等本轮载入完成。
+        std::lock_guard<std::mutex> alock(analyzerMutex_);
+        bool ok = native_ ? nativeAnalyzer_->getFramesByDisplayFilter(displayFilter, frames,
+                                                                      errorOut)
+                          : analyzer_.getFramesByDisplayFilter(displayFilter, frames, errorOut);
+        if (!ok)
+        {
+            return false;
+        }
+    }
+    // 从既有快照按帧号取报文，沿用快照里权威的 file_offset，过滤结果仍能正确取 hex。
+    std::set<uint32_t> keep(frames.begin(), frames.end());
+    std::shared_ptr<const std::vector<std::shared_ptr<Packet>>> snap;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        snap = packets_;
+    }
+    if (!snap)
     {
         return false;
     }
-    // 匹配帧号放进集合，再从既有快照按帧号取对应报文——快照里的 file_offset
-    // 是权威值，这样过滤结果依然能正确取 hex，无需 tshark 重算偏移。
-    std::set<uint32_t> keep(frames.begin(), frames.end());
-    std::lock_guard<std::mutex> lock(mutex_);
-    for (const std::shared_ptr<Packet>& p : packets_)
+    for (const std::shared_ptr<Packet>& p : *snap)
     {
         if (keep.count(static_cast<uint32_t>(p->frame_number)) > 0)
         {
@@ -229,6 +308,12 @@ bool AnalysisSession::savePcapAs(const std::string& destPath)
     if (destPath == srcPath)
     {
         return true; // 目标即源，视为成功
+    }
+    // 允许用户指定尚不存在的多层目录（如 data/exports/foo.pcap），先补齐父目录再拷贝。
+    if (!ensureParentDir(destPath))
+    {
+        LOG_F(ERROR, "创建保存目录失败: %s", destPath.c_str());
+        return false;
     }
     if (!copyFile(srcPath, destPath))
     {
@@ -269,29 +354,121 @@ bool AnalysisSession::exportDetailJson(const std::string& xmlPath, const std::st
     return true;
 }
 
+bool AnalysisSession::exportPacketsCsv(const std::string& csvPath)
+{
+    if (csvPath.empty())
+    {
+        LOG_F(ERROR, "导出 CSV 需要指定目标路径");
+        return false;
+    }
+    std::shared_ptr<const std::vector<std::shared_ptr<Packet>>> snap;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        snap = packets_;
+    }
+    if (!snap || snap->empty())
+    {
+        LOG_F(ERROR, "当前没有可导出的报文（请先载入或抓包）");
+        return false;
+    }
+
+    std::ofstream out(csvPath.c_str(), std::ios::trunc);
+    if (!out)
+    {
+        LOG_F(ERROR, "打开 CSV 文件失败: %s", csvPath.c_str());
+        return false;
+    }
+
+    // CSV 字段转义（内容来自不可信报文）：1) 公式注入防护——= + - @ Tab CR 开头前置单引号 '；
+    // 2) RFC 4180 转义——含逗号/引号/换行时用双引号包裹，内部 " 翻倍成 ""。
+    auto csvField = [](const std::string& v)
+    {
+        std::string s = v;
+        if (!s.empty())
+        {
+            char c0 = s[0];
+            if (c0 == '=' || c0 == '+' || c0 == '-' || c0 == '@' || c0 == '\t' || c0 == '\r')
+                s.insert(s.begin(), '\'');
+        }
+        bool needQuote = s.find(',') != std::string::npos || s.find('"') != std::string::npos ||
+                         s.find('\n') != std::string::npos || s.find('\r') != std::string::npos;
+        if (!needQuote)
+            return s;
+        std::string out2;
+        out2.reserve(s.size() + 2);
+        out2.push_back('"');
+        for (char c : s)
+        {
+            if (c == '"')
+                out2 += "\"\""; // 内部引号翻倍（勿写成 """"，会被当空字面量吞掉）
+            else
+                out2.push_back(c);
+        }
+        out2.push_back('"');
+        return out2;
+    };
+
+    out << "frame_number,time,src_mac,src_ip,src_location,src_port,dst_mac,dst_ip,"
+           "dst_location,dst_port,protocol,len,info\n";
+    char timeBuf[64];
+    for (const std::shared_ptr<Packet>& p : *snap)
+    {
+        // time 是 epoch 浮点秒，转成可读时间戳（毫秒精度）
+        std::snprintf(timeBuf, sizeof(timeBuf), "%.3f", p->time);
+        out << p->frame_number << ',' << timeBuf << ','
+            << csvField(p->src_mac) << ',' << csvField(p->src_ip) << ',' << csvField(p->src_location)
+            << ',' << p->src_port << ',' << csvField(p->dst_mac) << ',' << csvField(p->dst_ip)
+            << ',' << csvField(p->dst_location) << ',' << p->dst_port << ','
+            << csvField(p->protocol) << ',' << p->len << ',' << csvField(p->info) << '\n';
+        if (!out)
+        {
+            LOG_F(ERROR, "写 CSV 失败（磁盘满？）: %s", csvPath.c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
 std::vector<AdapterInfo> AnalysisSession::listAdapters() const
 {
-    return TsharkCommand::listNetworkAdapters(tsharkPath_);
+    return native_ ? NativeCapture::listAdapters()
+                   : TsharkCommand::listNetworkAdapters(tsharkPath_);
 }
 
 bool AnalysisSession::startLiveCapture(const std::string&           adapterName,
-                                       LiveCapture::PacketCallback onPacket)
+                                       LiveCapture::PacketCallback onPacket,
+                                       int durationSeconds)
 {
     if (capturing_)
     {
         LOG_F(WARNING, "已在抓包中，忽略重复的开始请求");
         return false;
     }
-    // 本次抓包按时间戳直接写入 pcaps 目录（不再落到 cwd，也不清空历史）。
+    // 按时间戳直接写入 pcaps 目录，历史不覆盖。
     std::string ts   = CommonUtil::get_timestamp();
     liveCapturePath_ = pcapsDir_ + "/capture_" + ts + ".pcap";
     liveDbPath_      = pcapsDir_ + "/packets_" + ts + ".db";
 
-    capture_.reset(new LiveCapture(tsharkPath_));
-    if (!capture_->startCapture(adapterName, std::move(onPacket), liveCapturePath_))
+    if (native_)
     {
-        capture_.reset();
-        return false;
+        // 自研抓包：libpcap 直接抓，无需 tshark 路径。
+        nativeCapture_.reset(new NativeCapture());
+        if (!nativeCapture_->startCapture(adapterName, std::move(onPacket), liveCapturePath_,
+                                          durationSeconds))
+        {
+            nativeCapture_.reset();
+            return false;
+        }
+    }
+    else
+    {
+        capture_.reset(new LiveCapture(tsharkPath_));
+        if (!capture_->startCapture(adapterName, std::move(onPacket), liveCapturePath_,
+                                    durationSeconds))
+        {
+            capture_.reset();
+            return false;
+        }
     }
     capturing_ = true;
     return true;
@@ -299,15 +476,28 @@ bool AnalysisSession::startLiveCapture(const std::string&           adapterName,
 
 bool AnalysisSession::stopLiveCapture()
 {
-    if (!capturing_ || !capture_)
+    if (!capturing_)
     {
         return false;
     }
-    capture_->stopCapture();
-    capture_.reset();
-    capturing_ = false;
+    if (native_)
+    {
+        if (!nativeCapture_)
+            return false;
+        nativeCapture_->stopCapture();
+        nativeCapture_.reset();
+        capturing_ = false;
+    }
+    else
+    {
+        if (!capture_)
+            return false;
+        capture_->stopCapture();
+        capture_.reset();
+        capturing_ = false;
+    }
 
-    // tshark 已把报文直接写到 liveCapturePath_（带时间戳），无需搬运，直接解析入库。
+    // 抓包已直接写到 liveCapturePath_，无需搬运，直接解析入库。
     return analyzeAndStore(liveCapturePath_, liveDbPath_);
 }
 
@@ -318,6 +508,11 @@ bool AnalysisSession::isCapturing() const
 
 void AnalysisSession::startFlowMonitor()
 {
+    if (native_)
+    {
+        LOG_F(WARNING, "自研引擎暂不支持网卡流量趋势监控（tshark 专属功能），已忽略");
+        return;
+    }
     if (!flow_)
     {
         flow_.reset(new FlowMonitor(tsharkPath_));

--- a/src/FlowMonitor.cpp
+++ b/src/FlowMonitor.cpp
@@ -33,16 +33,15 @@ FlowMonitor::~FlowMonitor()
 
 void FlowMonitor::stopMonitorAdaptersFlowTrend()
 {
-    // 第一步：置位停止标志并 join 监控线程。
-    // 关键：join 时绝不能持 adapterFlowTrendMapLock——监控线程内部要拿同一把锁，
-    // 否则死锁。故先在无锁状态下让线程收敛退出，再去撕毁 map。
+    // 先置停止标志并 join 监控线程。join 时绝不能持 adapterFlowTrendMapLock——
+    // 监控线程内部要拿同一把锁，否则死锁。故先无锁让线程退出，再撕毁 map。
     stopFlag = true;
     if (flowTrendThread.joinable())
     {
         flowTrendThread.join();
     }
 
-    // 第二步：线程已退出，可安全清理监控 map（此时无并发访问）
+    // 线程已退出，可安全清理监控 map（此时无并发访问）
     std::unique_lock<std::recursive_mutex> lock(adapterFlowTrendMapLock);
 
     for (const auto& adapterPipePair : adapterFlowTrendMonitorMap)
@@ -72,16 +71,12 @@ void FlowMonitor::stopMonitorAdaptersFlowTrend()
 void FlowMonitor::getAdaptersFlowTrendData(
     std::map<std::string, std::map<long, long>>& flowTrendData)
 {
-    // 先上锁再读 adapterFlowTrendMonitorStartTime：该值由 startMonitor 在锁内写入，
-    // 放到锁外读会与之竞态。锁同时保护随后对 adapterFlowTrendMonitorMap 的遍历。
+    // 锁保护 adapterFlowTrendMonitorStartTime（startMonitor 在锁内写）与随后对 map 的遍历。
     std::unique_lock<std::recursive_mutex> lock(adapterFlowTrendMapLock);
 
     long timeNow = time(nullptr);
 
-    // 滑动窗口的左右端点：
-    // 一开始：以最开始监控时间为左起点，终点为未来300秒
-    // 随着时间推移，数据逐渐填充完这300秒
-    // 超过300秒之后，结束节点就是当前，开始节点就是当前-300
+    // 滑动窗口左右端点：不足 300 秒时从监控起点算起，超过后取 [当前-300, 当前]。
     long startWindow = timeNow - adapterFlowTrendMonitorStartTime > 300
                            ? timeNow - 300
                            : adapterFlowTrendMonitorStartTime;
@@ -94,10 +89,8 @@ void FlowMonitor::getAdaptersFlowTrendData(
         auto&       targetSeries = flowTrendData[adapterPipePair.first];
         const auto& sourceSeries = adapterPipePair.second.flowTrendData;
 
-        // 稀疏拷贝：只搬运窗口 [startWindow, endWindow] 内“确实有流量”的秒，
-        // 不再对整个窗口逐秒稠密填 0。sourceSeries 是有序 map，用 lower_bound/
-        // upper_bound 定位区间端点即可，避免对上千秒的空洞做无谓插入。
-        // 语义变化：结果中缺失的秒表示该秒无流量（原实现会显式填 0）。
+        // 稀疏拷贝：只搬运窗口内“确实有流量”的秒（有序 map 用 lower/upper_bound 定位区间），
+        // 不逐秒填 0。语义变化：结果中缺失的秒表示该秒无流量。
         auto begin = sourceSeries.lower_bound(startWindow);
         auto end   = sourceSeries.upper_bound(endWindow);
         for (auto it = begin; it != end; ++it)
@@ -153,11 +146,11 @@ void FlowMonitor::startMonitorAdaptersFlowTrend()
         monitorInfo.monitorTsharkPipe = pipe;
         monitorInfo.tsharkPid         = tsharkPid;
 
-        // 建立 fd → 网卡监控状态的 O(1) 反查索引（monitorInfo 是 map 内元素，地址稳定）
+        // fd → 网卡监控状态的 O(1) 反查索引（monitorInfo 是 map 内元素，地址稳定）
         fdToAdapter[pipeFd] = &monitorInfo;
     }
 
-    // 启动监控线程处理轮询事件（joinable，由 stopMonitor / 析构负责 join）
+    // 启动监控线程（joinable，由 stopMonitor / 析构负责 join）
     flowTrendThread = std::thread(&FlowMonitor::adapterFlowTrendMonitorThreadEntry, this);
 }
 
@@ -200,9 +193,8 @@ void accumulateFlowLine(const std::string& line, AdapterMonitorInfo& info)
 
 void FlowMonitor::adapterFlowTrendMonitorThreadEntry()
 {
-    // 每 500ms 轮询一次：既能及时响应新数据，也能在所有网卡管道都关闭后
-    // （size()==0）干净退出线程，避免原先 while(true)+epoll_wait(-1) 的线程泄漏。
-    // stopFlag 用于让 stopMonitor 主动打断轮询、令线程尽快 join。
+    // 每 500ms 轮询一次：及时响应新数据，也能在所有管道关闭(size()==0)后干净退出，避免线程泄漏。
+    // stopFlag 让 stopMonitor 主动打断轮询、令线程尽快 join。
     while (!stopFlag && flowTrendPoller.size() > 0)
     {
         std::vector<int> readyFds = flowTrendPoller.wait(500);
@@ -211,8 +203,7 @@ void FlowMonitor::adapterFlowTrendMonitorThreadEntry()
         {
             int pipeFd = readyFds[idx];
 
-            // 先 O(1) 定位该 fd 对应的网卡监控状态，本轮所有读入都归到它名下。
-            // map 元素地址稳定、且 stopMonitor 会先 join 本线程再动 map，故指针在本轮有效。
+            // O(1) 定位该 fd 的网卡监控状态。map 元素地址稳定、stopMonitor 会先 join 再动 map，故指针本轮有效。
             AdapterMonitorInfo* info = nullptr;
             {
                 std::unique_lock<std::recursive_mutex> lock(adapterFlowTrendMapLock);
@@ -236,8 +227,7 @@ void FlowMonitor::adapterFlowTrendMonitorThreadEntry()
                 std::unique_lock<std::recursive_mutex> lock(adapterFlowTrendMapLock);
                 info->readLeftover.append(buffer, static_cast<size_t>(bytesRead));
 
-                // 一次 read 可能含多行，也可能以半行结尾：切出所有完整行逐一解析，
-                // 未完成的行尾留在 readLeftover 等下次 read 续上（旧实现只解析首行）。
+                // 一次 read 可能含多行或半行：切出所有完整行逐一解析，未完成的行尾留在 readLeftover 续上。
                 size_t nl;
                 while ((nl = info->readLeftover.find('\n')) != std::string::npos)
                 {
@@ -258,15 +248,13 @@ void FlowMonitor::adapterFlowTrendMonitorThreadEntry()
                 if (it != fdToAdapter.end())
                 {
                     AdapterMonitorInfo* dead = it->second;
-                    // 回收子进程避免僵尸，并把句柄置为无效，防止 stopMonitor 再对
-                    // 可能被系统复用的 pid/句柄误发信号。
+                    // 回收子进程避免僵尸，句柄置无效防止 stopMonitor 对复用的 pid 误发信号。
                     if (ProcessUtil::ValidProc(dead->tsharkPid))
                     {
                         ProcessUtil::Kill(dead->tsharkPid);
                         dead->tsharkPid = ProcessUtil::kInvalidProc;
                     }
-                    // fclose 连带关闭底层 fd 并置空——绝不能再 close(pipeFd)，否则与
-                    // fclose 造成对同一 fd 的二次关闭。置空后 stopMonitor 见空即跳过。
+                    // fclose 连带关闭底层 fd 并置空，绝不能再 close(pipeFd) 造成二次关闭。
                     if (dead->monitorTsharkPipe)
                     {
                         fclose(dead->monitorTsharkPipe);

--- a/src/LiveCapture.cpp
+++ b/src/LiveCapture.cpp
@@ -14,6 +14,7 @@ LiveCapture::LiveCapture(const std::string& tsharkPath, const std::string& ip2Re
     : tsharkPath_(tsharkPath),
       ip2RegionDbPath_(ip2RegionDbPath),
       stopFlag_(false),
+      running_(false),
       startFailed_(false),
       tsharkPid_(ProcessUtil::kInvalidProc)
 {
@@ -21,11 +22,23 @@ LiveCapture::LiveCapture(const std::string& tsharkPath, const std::string& ip2Re
 
 LiveCapture::~LiveCapture()
 {
-    stopCapture(); // 兜底：避免析构时线程/子进程悬挂
+    // 兜底：避免析构时线程/子进程悬挂。不能只调 stopCapture()——线程可能已自然退出
+    // 但 captureWorkThread_ 仍 joinable，不 join 直接释放会 std::terminate。故独立处理。
+    if (captureWorkThread_)
+    {
+        stopFlag_ = true;
+        ProcessUtil::ProcHandle pid = tsharkPid_.load();
+        if (ProcessUtil::ValidProc(pid))
+            ProcessUtil::Signal(pid);
+        if (captureWorkThread_->joinable())
+            captureWorkThread_->join();
+        captureWorkThread_.reset();
+        running_ = false;
+    }
 }
 
 bool LiveCapture::startCapture(const std::string& adapterName, PacketCallback onPacket,
-                               const std::string& captureFile)
+                               const std::string& captureFile, int durationSeconds)
 {
     if (captureWorkThread_)
     {
@@ -35,14 +48,15 @@ bool LiveCapture::startCapture(const std::string& adapterName, PacketCallback on
     LOG_F(INFO, "即将开始抓包，网卡：%s", adapterName.c_str());
     stopFlag_    = false;
     startFailed_ = false;
+    running_     = true;
     tsharkPid_   = ProcessUtil::kInvalidProc;
     captureWorkThread_ = std::make_shared<std::thread>(&LiveCapture::captureWorkThreadEntry, this,
-                                                       adapterName, captureFile, std::move(onPacket));
+                                                       adapterName, captureFile, std::move(onPacket),
+                                                       durationSeconds);
 
-    // 工作线程要过一会儿才真正 fork 出 tshark，这里等它给出确定结果：
-    //   成功 → tsharkPid_ 落定(>0)；失败 → startFailed_ 置位。
-    // 否则 startCapture 恒返回 true，PopenEx 失败时 isCapturing() 会误报“在抓包”。
-    // 极窄启动窗口内轮询，最多约 1s；超时仍未定则乐观返回（tshark 可能只是启动慢）。
+    // 等工作线程给出确定结果：成功 → tsharkPid_ 落定(>0)；失败 → startFailed_ 置位。
+    // 否则 PopenEx 失败时 startCapture 恒返回 true，isCapturing() 会误报“在抓包”。
+    // 轮询最多约 1s，超时仍未定则乐观返回（tshark 可能只是启动慢）。
     for (int i = 0; i < 200; ++i)
     {
         if (ProcessUtil::ValidProc(tsharkPid_.load()))
@@ -61,14 +75,14 @@ bool LiveCapture::startCapture(const std::string& adapterName, PacketCallback on
 
 bool LiveCapture::stopCapture()
 {
-    if (!captureWorkThread_)
+    if (!running_ || !captureWorkThread_)
         return false; // 未在抓包 / 已停止：幂等，避免二次 join 抛异常
 
     LOG_F(INFO, "即将停止抓包");
     stopFlag_ = true;
 
-    // tshark 往 -w 文件写、几乎不写 stdout，只关管道它不会退出：必须发信号令其收尾，
-    // 读循环随之 EOF 退出。极窄的启动窗口内 pid 可能尚未就位，短暂等待其落定。
+    // tshark 只关管道不会退出，必须发信号令其收尾，读循环随之 EOF 退出。
+    // 启动窗口内 pid 可能尚未就位，短暂等待其落定。
     ProcessUtil::ProcHandle pid = tsharkPid_.load();
     for (int i = 0; !ProcessUtil::ValidProc(pid) && i < 200; ++i)
     {
@@ -77,27 +91,33 @@ bool LiveCapture::stopCapture()
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         pid = tsharkPid_.load();
     }
-    // 只发信号、不回收 —— 交给工作线程里的 PcloseEx 统一回收，避免双重回收。
-    // POSIX 为 SIGTERM（tshark 优雅收尾）；Windows 为 TerminateProcess（无法 flush，见 Signal 注释）。
+    // 只发信号、不回收——交给工作线程里的 PcloseEx 统一回收，避免双重回收。
+    // POSIX 用 SIGTERM 优雅收尾；Windows 用 TerminateProcess（无法 flush，见 Signal 注释）。
     if (ProcessUtil::ValidProc(pid))
         ProcessUtil::Signal(pid);
 
     if (captureWorkThread_->joinable())
         captureWorkThread_->join();
     captureWorkThread_.reset();
+    running_ = false;
     return true;
 }
 
 void LiveCapture::captureWorkThreadEntry(std::string adapterName, std::string captureFile,
-                                         PacketCallback onPacket)
+                                         PacketCallback onPacket, int durationSeconds)
 {
     try
     {
-        // -i 抓指定网卡；-l 行缓冲即时输出；-w + -F pcap 落盘原始报文；
-        // -P 令即便写文件也把包摘要打到 stdout；随后接共享字段列表（-T fields -e ...），
-        // 字段顺序与 PacketParser::parseLine 严格对应，可与离线路径复用同一解析器。
+        // -i 网卡；-l 行缓冲；-w+-F pcap 落盘；-P 写文件时仍把摘要打到 stdout；随后接字段列表，
+        // 字段顺序与 PacketParser::parseLine 严格对应，与离线路径复用同一解析器。
         std::vector<std::string> tsharkArgs = {tsharkPath_, "-i",   adapterName, "-l", "-w",
                                                captureFile, "-F",   "pcap",      "-P"};
+        if (durationSeconds > 0)
+        {
+            // -a duration:N：tshark 抓满 N 秒自行收尾退出（CLI“抓 N 秒”场景；GUI/Web 手动停止不走这里）。
+            tsharkArgs.push_back("-a");
+            tsharkArgs.push_back("duration:" + std::to_string(durationSeconds));
+        }
         std::vector<std::string> fieldArgs = TsharkCommand::tsharkFieldArgs();
         tsharkArgs.insert(tsharkArgs.end(), fieldArgs.begin(), fieldArgs.end());
 
@@ -116,16 +136,14 @@ void LiveCapture::captureWorkThreadEntry(std::string adapterName, std::string ca
         bool ip2RegionReady = IP2RegionUtil::init(ip2RegionDbPath_);
 
         char buffer[8192];
-        // 报文在 capture.pcap 中的偏移：首包紧随 24 字节全局文件头(sizeof(PcapHeader))之后。
-        // 用 64 位累加，避免长时间抓包偏移超过 4GB 溢出。
+        // 报文偏移：首包紧随 24 字节全局文件头之后。用 64 位累加避免长时间抓包超 4GB 溢出。
         uint64_t file_offset = sizeof(PcapHeader);
         while (!stopFlag_ && fgets(buffer, sizeof(buffer), pipe) != nullptr)
         {
             std::shared_ptr<Packet> packet = std::make_shared<Packet>();
             if (!PacketParser::parseLine(buffer, *packet))
             {
-                // 实时路径：单行解析失败就跳过（可能是 tshark 的状态行），不中止整轮。
-                // 偏移可能就此错位，但实时展示以“尽力而为”为主；停止后会离线重解析纠正。
+                // 实时路径单行解析失败就跳过（可能是状态行），偏移或就此错位，停止后离线重解析纠正。
                 continue;
             }
             packet->file_offset = file_offset + sizeof(PacketHeader);
@@ -143,14 +161,17 @@ void LiveCapture::captureWorkThreadEntry(std::string adapterName, std::string ca
 
         ProcessUtil::PcloseEx(pipe, tsharkPid); // fclose + 回收，单点回收
         tsharkPid_ = ProcessUtil::kInvalidProc;
+        running_   = false;
         LOG_F(INFO, "Capture thread exiting gracefully.");
     }
     catch (const std::exception& e)
     {
+        running_ = false;
         LOG_F(ERROR, "Exception in captureWorkThreadEntry: %s", e.what());
     }
     catch (...)
     {
+        running_ = false;
         LOG_F(ERROR, "Unknown exception in captureWorkThreadEntry.");
     }
 }

--- a/src/NativeAnalyzer.cpp
+++ b/src/NativeAnalyzer.cpp
@@ -1,0 +1,343 @@
+#include "NativeAnalyzer.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
+#include "NativePacketParser.hpp"
+#include "loguru/loguru.hpp"
+
+namespace
+{
+uint32_t rdLe32(const unsigned char* p)
+{
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+uint16_t rdLe16(const unsigned char* p)
+{
+    return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+uint32_t rdBe32(const unsigned char* p)
+{
+    return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16) |
+           (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
+}
+
+// 经典 pcap 小端 magic
+bool isPcapLe(const unsigned char* p)
+{
+    return p[0] == 0xd4 && p[1] == 0xc3 && p[2] == 0xb2 && p[3] == 0xa1;
+}
+// pcap 大端 magic
+bool isPcapBe(const unsigned char* p)
+{
+    return p[0] == 0xa1 && p[1] == 0xb2 && p[2] == 0xc3 && p[3] == 0xd4;
+}
+// 纳秒精度经典 pcap magic（0xa1b23c4d）：布局同微秒版，仅时间戳小数字段单位为纳秒。
+bool isPcapLeNano(const unsigned char* p)
+{
+    return p[0] == 0x4d && p[1] == 0x3c && p[2] == 0xb2 && p[3] == 0xa1;
+}
+bool isPcapBeNano(const unsigned char* p)
+{
+    return p[0] == 0xa1 && p[1] == 0xb2 && p[2] == 0x3c && p[3] == 0x4d;
+}
+// pcapng：SHB 块类型（小端 0x0A0D0D0A）
+bool isPcapNg(const unsigned char* p)
+{
+    return p[0] == 0x0a && p[1] == 0x0d && p[2] == 0x0d && p[3] == 0x0a;
+}
+
+// 只保留能正确解析的链路类型；未知类型按 Ethernet 兜底。
+// 0=NULL/Loopback，1=Ethernet，113=Linux SLL，276=Linux SLL2。
+uint32_t normalizeLinkType(uint32_t lt)
+{
+    if (lt == 0 || lt == 1 || lt == 113 || lt == 276)
+        return lt;
+    return 1;
+}
+
+// pcapng if_tsresol（选项码 9，1 字节）→「每秒 tick 数」除数。
+// 高位(0x80)置位：分辨率 = 2^-(v&0x7f) 秒 → 除数 = 2^(v&0x7f)；
+// 否则：分辨率 = 10^-v 秒 → 除数 = 10^v。缺省 v=6（微秒）→ 除数 1e6。
+double tsResolDivisor(uint8_t v)
+{
+    if (v & 0x80)
+    {
+        double d = 1.0;
+        for (uint8_t i = 0; i < (v & 0x7f); ++i)
+            d *= 2.0;
+        return d;
+    }
+    double d = 1.0;
+    for (uint8_t i = 0; i < v; ++i)
+        d *= 10.0;
+    return d;
+}
+
+// 解析 pcapng IDB 块：取 LinkType 与 if_tsresol。blk 指向块首（含 8 字节块头）。
+// IDB 体：LinkType(2) Reserved(2) SnapLen(4)，随后是 TLV 选项（if_tsresol 码=9）。
+void parseIdb(const unsigned char* blk, uint32_t total, uint32_t& linkType, double& tsDivisor)
+{
+    linkType  = 1;
+    tsDivisor = 1e6; // 默认微秒
+    if (total < 20)
+        return;
+    linkType = rdLe16(blk + 8);
+    // 选项从块内偏移 16 开始，扫到块尾长度字段（total-4）之前
+    uint32_t off = 16;
+    uint32_t end = total - 4;
+    while (off + 4 <= end)
+    {
+        uint16_t code = rdLe16(blk + off);
+        uint16_t olen = rdLe16(blk + off + 2);
+        if (code == 0) // opt_endofopt
+            break;
+        if (code == 9 && olen >= 1 && off + 4 + olen <= total) // if_tsresol
+        {
+            tsDivisor = tsResolDivisor(blk[off + 4]);
+        }
+        // 选项值按 4 字节对齐
+        off += 4 + ((olen + 3u) & ~3u);
+    }
+}
+
+// 经典 pcap 记录遍历（24 字节全局头 + 16 字节记录头 + 数据）。LE/BE/微秒/纳秒四种组合仅字节序与
+// 时间戳单位不同，故用读取函子 rd32（rdLe32/rdBe32）与除数 tsDiv（1e6/1e9）参数化，共用一份循环。
+void parseClassicPcap(PcapFileReader& reader, uint64_t fileSize,
+                      uint32_t (*rd32)(const unsigned char*), double tsDiv, int linkType,
+                      std::vector<std::shared_ptr<Packet>>& packets)
+{
+    uint64_t pos   = 24;
+    int      frame = 1;
+    for (;;)
+    {
+        if (pos + 16 > fileSize)
+            break; // 文件尾
+        const unsigned char* rh = reader.viewAt(pos, 16);
+        if (!rh)
+            break;
+        uint32_t tsSec   = rd32(rh);
+        uint32_t tsFrac  = rd32(rh + 4);
+        uint32_t caplen  = rd32(rh + 8);
+        uint32_t origlen = rd32(rh + 12);
+        uint64_t dataOff = pos + 16;
+        // 零拷贝借出帧字节，直接在映射区上解析（rh 的标量已全部取出，安全被覆盖）
+        const unsigned char* data = reader.viewAt(dataOff, caplen);
+        if (!data)
+        {
+            LOG_F(ERROR, "NativeAnalyzer: 记录 %d 数据越界", frame);
+            break;
+        }
+        Packet p;
+        p.frame_number = frame;
+        p.time         = static_cast<double>(tsSec) + static_cast<double>(tsFrac) / tsDiv;
+        p.cap_len      = caplen;
+        p.len          = origlen ? origlen : caplen;
+        p.file_offset  = dataOff;
+        NativePacketParser::parseFrame(data, caplen, p, linkType);
+
+        packets.push_back(std::make_shared<Packet>(std::move(p)));
+        pos += 16 + static_cast<uint64_t>(caplen);
+        ++frame;
+    }
+}
+} // namespace
+
+bool NativeAnalyzer::analyzeFile(const std::string& filePath,
+                                 std::vector<std::shared_ptr<Packet>>& out)
+{
+    packets_.clear();
+    analyzed_  = false;
+    linkType_  = 1;
+
+    if (!reader_.open(filePath))
+    {
+        LOG_F(ERROR, "NativeAnalyzer: 打开文件失败 %s", filePath.c_str());
+        return false;
+    }
+    currentPath_ = filePath;
+
+    const uint64_t fileSize = reader_.size();
+    // 预留容量：按平均帧 ~64 字节保守估计包数，减少 push_back 扩容（估偏只影响扩容次数）。
+    packets_.reserve(static_cast<size_t>(fileSize / 64) + 16);
+
+    // 读文件头判断格式（一次性，非热点，但同样走零拷贝 viewAt）
+    const unsigned char* head = reader_.viewAt(0, 4);
+    if (!head)
+    {
+        LOG_F(ERROR, "NativeAnalyzer: 文件过小 %s", filePath.c_str());
+        return false;
+    }
+
+    if (isPcapLe(head) || isPcapLeNano(head))
+    {
+        // 经典小端 pcap：24 字节全局头 + 16 字节记录头。微秒版除数 1e6，纳秒版 1e9。
+        const unsigned char* gh = reader_.viewAt(0, 24);
+        if (!gh)
+            return false;
+        // 链路类型：全局头偏移 20 的 network 字段
+        uint32_t linkType = normalizeLinkType(rdLe32(gh + 20));
+        linkType_         = static_cast<int>(linkType);
+        double tsDiv      = isPcapLeNano(head) ? 1e9 : 1e6;
+        parseClassicPcap(reader_, fileSize, &rdLe32, tsDiv, static_cast<int>(linkType), packets_);
+    }
+    else if (isPcapBe(head) || isPcapBeNano(head))
+    {
+        // 经典大端 pcap：同布局，字段大端。
+        const unsigned char* gh = reader_.viewAt(0, 24);
+        if (!gh)
+            return false;
+        uint32_t linkType = normalizeLinkType(rdBe32(gh + 20));
+        linkType_         = static_cast<int>(linkType);
+        double tsDiv      = isPcapBeNano(head) ? 1e9 : 1e6;
+        parseClassicPcap(reader_, fileSize, &rdBe32, tsDiv, static_cast<int>(linkType), packets_);
+    }
+    else if (isPcapNg(head))
+    {
+        // pcapng：SHB + IDB + EPB/SPB 块。块布局：Type(4) + TotalLen(4) + 载荷 + TotalLen(4)。
+        // 逐接口记录 LinkType 与时间戳分辨率（IDB 的 if_tsresol），EPB 按 interface_id 选用。
+        std::vector<uint32_t> ifLink;    // 各接口链路类型
+        std::vector<double>   ifTsDiv;   // 各接口时间戳除数（tick/秒）
+        uint64_t              pos = 0;
+        int                   frame = 1;
+        for (;;)
+        {
+            if (pos + 8 > fileSize)
+                break;
+            const unsigned char* hdr = reader_.viewAt(pos, 8);
+            if (!hdr)
+                break;
+            uint32_t type  = rdLe32(hdr);
+            uint32_t total = rdLe32(hdr + 4);
+            if (total < 12 || total > 64 * 1024 * 1024 || pos + total > fileSize)
+                break; // 损坏保护
+            if (type == 0x00000001) // IDB
+            {
+                const unsigned char* blk = reader_.viewAt(pos, total);
+                uint32_t lt = 1;
+                double   div = 1e6;
+                if (blk)
+                    parseIdb(blk, total, lt, div);
+                ifLink.push_back(normalizeLinkType(lt));
+                ifTsDiv.push_back(div);
+                if (ifLink.size() == 1)
+                    linkType_ = static_cast<int>(ifLink[0]); // 详情树用首个接口的链路类型
+            }
+            else if (type == 0x00000006) // EPB：interface(4) tsHigh(4) tsLow(4) capLen(4) origLen(4) data
+            {
+                const unsigned char* body = reader_.viewAt(pos + 8, 20);
+                if (!body)
+                    break;
+                uint32_t ifId    = rdLe32(body);
+                uint32_t tsHigh  = rdLe32(body + 4);
+                uint32_t tsLow   = rdLe32(body + 8);
+                uint32_t capLen  = rdLe32(body + 12);
+                uint32_t origLen = rdLe32(body + 16);
+                // capLen 取自文件字段，须按块长夹紧（块头 8 + body 20 + 尾长 4 = 32）；否则伪造的 capLen 会越读后续块字节。
+                if (total >= 32 && capLen > total - 32)
+                    capLen = total - 32;
+                uint64_t dataOff = pos + 28;
+                const unsigned char* data = reader_.viewAt(dataOff, capLen);
+                if (!data)
+                    break;
+                double div = (ifId < ifTsDiv.size()) ? ifTsDiv[ifId] : 1e6;
+                int    lt  = (ifId < ifLink.size()) ? static_cast<int>(ifLink[ifId]) : linkType_;
+                double ts  = static_cast<double>((static_cast<uint64_t>(tsHigh) << 32) | tsLow) /
+                            div;
+                Packet p;
+                p.frame_number = frame;
+                p.time         = ts;
+                p.cap_len      = capLen;
+                p.len          = origLen ? origLen : capLen;
+                p.file_offset  = dataOff;
+                NativePacketParser::parseFrame(data, capLen, p, lt);
+                packets_.push_back(std::make_shared<Packet>(std::move(p)));
+                ++frame;
+            }
+            else if (type == 0x00000003) // SPB：origLen(4) + data（无时间戳，约定用接口 0）
+            {
+                const unsigned char* body = reader_.viewAt(pos + 8, 4);
+                if (!body)
+                    break;
+                uint32_t origLen = rdLe32(body);
+                uint64_t dataOff = pos + 12;
+                uint32_t capLen  = (total >= 16) ? (total - 16) : origLen;
+                if (capLen > origLen)
+                    capLen = origLen;
+                const unsigned char* data = reader_.viewAt(dataOff, capLen);
+                if (!data)
+                    break;
+                int lt = ifLink.empty() ? linkType_ : static_cast<int>(ifLink[0]);
+                Packet p;
+                p.frame_number = frame;
+                p.time         = 0.0;
+                p.cap_len      = capLen;
+                p.len          = origLen;
+                p.file_offset  = dataOff;
+                NativePacketParser::parseFrame(data, capLen, p, lt);
+                packets_.push_back(std::make_shared<Packet>(std::move(p)));
+                ++frame;
+            }
+            // 其他块（SHB/NRB/自定义）跳过
+            pos += total;
+        }
+    }
+    else
+    {
+        LOG_F(ERROR, "NativeAnalyzer: 无法识别的文件格式 %s", filePath.c_str());
+        return false;
+    }
+
+    analyzed_ = true;
+    out = packets_; // 共享同一批 shared_ptr（浅拷贝指针，不复制 Packet）
+    LOG_F(INFO, "NativeAnalyzer: %s 共解析 %zu 包", filePath.c_str(), packets_.size());
+    return true;
+}
+
+bool NativeAnalyzer::getPacketHexData(uint32_t frameNumber,
+                                      std::vector<unsigned char>& out) const
+{
+    if (!analyzed_ || frameNumber == 0 || frameNumber > packets_.size())
+        return false;
+    const Packet& p = *packets_[frameNumber - 1];
+    return reader_.readAt(p.file_offset, p.cap_len, out);
+}
+
+bool NativeAnalyzer::getPacketDetailTree(uint32_t frameNumber, DetailNode& root) const
+{
+    if (!analyzed_ || frameNumber == 0 || frameNumber > packets_.size())
+        return false;
+    const Packet& p = *packets_[frameNumber - 1];
+    // 零拷贝借出原始帧字节；用分析时确定的链路类型，保证 SLL/NULL 等非以太网帧也能正确重解析。
+    const unsigned char* raw = reader_.viewAt(p.file_offset, p.cap_len);
+    if (!raw)
+        return false;
+    return NativePacketParser::buildDetailTree(raw, p.cap_len, linkType_, frameNumber, root);
+}
+
+bool NativeAnalyzer::getFramesByDisplayFilter(const std::string& expr,
+                                              std::vector<uint32_t>& frames,
+                                              std::string* err) const
+{
+    frames.clear();
+    if (!analyzed_)
+    {
+        if (err)
+            *err = "尚未分析任何文件";
+        return false;
+    }
+    // 编译一次：把表达式解析成可复用谓词，避免对每个包重新词法/语法分析。
+    std::string                        localErr;
+    std::function<bool(const Packet&)> pred =
+        NativePacketParser::compileDisplayFilter(expr, err ? err : &localErr);
+    if (!pred)
+        return false; // 表达式非法（原因已写入 err）
+    for (const auto& p : packets_)
+    {
+        if (pred(*p))
+            frames.push_back(static_cast<uint32_t>(p->frame_number));
+    }
+    return true;
+}

--- a/src/NativeCapture.cpp
+++ b/src/NativeCapture.cpp
@@ -1,0 +1,210 @@
+#include "NativeCapture.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+#include "NativePacketParser.hpp"
+#include "loguru/loguru.hpp"
+
+#if defined(EASYTSHARK_HAVE_LIBPCAP)
+#include <pcap.h>
+#endif
+
+namespace
+{
+// 写经典小端 pcap 全局头
+void writePcapGlobalHeader(FILE* f)
+{
+    // magic d4c3b2a1 + 2.4 + thiszone 0 + sigfigs 0 + snaplen 65535 + network 1(Ethernet)
+    unsigned char hdr[24] = {0xd4, 0xc3, 0xb2, 0xa1, 0x02, 0x00, 0x04, 0x00,
+                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                             0xff, 0xff, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00};
+    std::fwrite(hdr, 1, sizeof(hdr), f);
+}
+
+void writePcapRecord(FILE* f, uint32_t tsSec, uint32_t tsUsec, const unsigned char* data,
+                     uint32_t caplen, uint32_t origlen)
+{
+    unsigned char rh[16];
+    rh[0]  = tsSec & 0xff;
+    rh[1]  = (tsSec >> 8) & 0xff;
+    rh[2]  = (tsSec >> 16) & 0xff;
+    rh[3]  = (tsSec >> 24) & 0xff;
+    rh[4]  = tsUsec & 0xff;
+    rh[5]  = (tsUsec >> 8) & 0xff;
+    rh[6]  = (tsUsec >> 16) & 0xff;
+    rh[7]  = (tsUsec >> 24) & 0xff;
+    rh[8]  = caplen & 0xff;
+    rh[9]  = (caplen >> 8) & 0xff;
+    rh[10] = (caplen >> 16) & 0xff;
+    rh[11] = (caplen >> 24) & 0xff;
+    rh[12] = origlen & 0xff;
+    rh[13] = (origlen >> 8) & 0xff;
+    rh[14] = (origlen >> 16) & 0xff;
+    rh[15] = (origlen >> 24) & 0xff;
+    std::fwrite(rh, 1, sizeof(rh), f);
+    std::fwrite(data, 1, caplen, f);
+}
+} // namespace
+
+NativeCapture::NativeCapture() = default;
+
+NativeCapture::~NativeCapture()
+{
+    if (thread_)
+    {
+        stopFlag_ = true;
+        if (thread_->joinable())
+            thread_->join();
+        thread_.reset();
+        running_ = false;
+    }
+}
+
+bool NativeCapture::startCapture(const std::string& adapterName, PacketCallback onPacket,
+                                 const std::string& captureFile, int durationSeconds)
+{
+    if (running_)
+    {
+        LOG_F(WARNING, "NativeCapture: 已在抓包中");
+        return false;
+    }
+    stopFlag_ = false;
+    running_  = true;
+    thread_   = std::make_shared<std::thread>(&NativeCapture::workThread, this, adapterName,
+                                              onPacket, captureFile, durationSeconds);
+    return true;
+}
+
+bool NativeCapture::stopCapture()
+{
+    if (!running_ || !thread_)
+        return false;
+    stopFlag_ = true;
+    if (thread_->joinable())
+        thread_->join();
+    thread_.reset();
+    running_ = false;
+    return true;
+}
+
+std::vector<AdapterInfo> NativeCapture::listAdapters()
+{
+    std::vector<AdapterInfo> out;
+#if defined(EASYTSHARK_HAVE_LIBPCAP)
+    char errbuf[PCAP_ERRBUF_SIZE] = {0};
+    pcap_if_t* alldevs = nullptr;
+    if (pcap_findalldevs(&alldevs, errbuf) != 0)
+    {
+        LOG_F(WARNING, "NativeCapture: pcap_findalldevs 失败: %s", errbuf);
+        return out;
+    }
+    int id = 1;
+    for (pcap_if_t* d = alldevs; d; d = d->next)
+    {
+        if (!d->name)
+            continue;
+        AdapterInfo ai;
+        ai.id    = id++;
+        ai.name  = d->name;
+        ai.remark = d->description ? d->description : d->name;
+        out.push_back(ai);
+    }
+    pcap_freealldevs(alldevs);
+#else
+    LOG_F(WARNING, "NativeCapture: 未编译 libpcap 支持，无法枚举网卡");
+#endif
+    return out;
+}
+
+void NativeCapture::workThread(std::string adapterName, PacketCallback onPacket,
+                               std::string captureFile, int durationSeconds)
+{
+#if defined(EASYTSHARK_HAVE_LIBPCAP)
+    char errbuf[PCAP_ERRBUF_SIZE] = {0};
+    pcap_t* handle = pcap_open_live(adapterName.c_str(), 65535, 0 /*非混杂*/, 100 /*ms*/,
+                                    errbuf);
+    if (!handle)
+    {
+        LOG_F(ERROR, "NativeCapture: 打开网卡 %s 失败: %s", adapterName.c_str(), errbuf);
+        running_ = false;
+        return;
+    }
+    // 非阻塞读取：配合 stopFlag_ 轮询退出（避免阻塞在 pcap_next_ex 上无法停止）
+    if (pcap_setnonblock(handle, 1, errbuf) != 0)
+        LOG_F(WARNING, "NativeCapture: 设置非阻塞失败: %s", errbuf);
+
+    FILE* out = nullptr;
+    if (!captureFile.empty())
+    {
+        out = std::fopen(captureFile.c_str(), "wb");
+        if (out)
+            writePcapGlobalHeader(out);
+        else
+            LOG_F(WARNING, "NativeCapture: 无法打开落盘文件 %s（仅实时展示）", captureFile.c_str());
+    }
+
+    // 链路类型传给解析器（帧结构不同）：DLT_NULL=0, DLT_EN10MB=1；其余传 -1 让解析器自动检测。
+    int linkType = -1;
+    int dl       = pcap_datalink(handle);
+    if (dl == DLT_NULL)
+        linkType = 0;
+    else if (dl == DLT_EN10MB)
+        linkType = 1;
+
+    LOG_F(INFO, "NativeCapture: 开始抓包 %s → %s（linktype=%d）", adapterName.c_str(),
+          captureFile.c_str(), dl);
+    auto   startTime = std::chrono::steady_clock::now();
+    int    frame     = 1;
+    while (!stopFlag_)
+    {
+        // 时长限制：到点退出（等价 tshark -a duration:N）
+        if (durationSeconds > 0 &&
+            std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
+                                                             startTime)
+                    .count() >= durationSeconds)
+            break;
+
+        struct pcap_pkthdr* hdr = nullptr;
+        const unsigned char* data = nullptr;
+        int rc = pcap_next_ex(handle, &hdr, &data);
+        if (rc == 1 && hdr && data && hdr->caplen > 0)
+        {
+            if (out)
+                writePcapRecord(out, hdr->ts.tv_sec, static_cast<uint32_t>(hdr->ts.tv_usec),
+                                data, hdr->caplen, hdr->len);
+            Packet p;
+            p.frame_number = frame++;
+            p.time         = static_cast<double>(hdr->ts.tv_sec) +
+                             static_cast<double>(hdr->ts.tv_usec) / 1e6;
+            p.cap_len = hdr->caplen;
+            p.len     = hdr->len;
+            NativePacketParser::parseFrame(data, hdr->caplen, p, linkType);
+            if (onPacket)
+                onPacket(std::make_shared<Packet>(p));
+        }
+        else if (rc == -1)
+        {
+            LOG_F(ERROR, "NativeCapture: 抓包错误: %s", pcap_geterr(handle));
+            break;
+        }
+        else
+        {
+            // rc == 0：非阻塞超时（100ms），继续轮询 stopFlag
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+    }
+
+    if (out)
+    {
+        std::fflush(out);
+        std::fclose(out);
+    }
+    pcap_close(handle);
+    LOG_F(INFO, "NativeCapture: 抓包结束，共 %d 包", frame - 1);
+#else
+    LOG_F(ERROR, "NativeCapture: 未编译 libpcap 支持，无法抓包");
+#endif
+    running_ = false;
+}

--- a/src/NativePacketParser.cpp
+++ b/src/NativePacketParser.cpp
@@ -1,0 +1,1375 @@
+#include "NativePacketParser.hpp"
+
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
+namespace NativePacketParser
+{
+namespace
+{
+// ---- 字节序工具（网络序 = 大端）----
+uint16_t rd16(const unsigned char* p)
+{
+    return static_cast<uint16_t>((p[0] << 8) | p[1]);
+}
+uint32_t rd32(const unsigned char* p)
+{
+    return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16) |
+           (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
+}
+
+std::string macToStr(const unsigned char* p)
+{
+    char buf[18];
+    std::snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3],
+                  p[4], p[5]);
+    return std::string(buf);
+}
+
+std::string ipv4ToStr(const unsigned char* p)
+{
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%u.%u.%u.%u", p[0], p[1], p[2], p[3]);
+    return std::string(buf);
+}
+
+std::string ipv6ToStr(const unsigned char* p)
+{
+    char buf[40];
+    int  pos = 0;
+    for (int i = 0; i < 8; ++i)
+    {
+        pos += std::snprintf(buf + pos, sizeof(buf) - pos, "%02x%02x", p[i * 2], p[i * 2 + 1]);
+        if (i < 7)
+            buf[pos++] = ':';
+    }
+    return std::string(buf);
+}
+
+// TCP flags → "[SYN, ACK]" 写入定长栈缓冲（无 flag 写空串），省去每包临时 std::string。
+void tcpFlagsToBuf(char* out, size_t n, unsigned char flags)
+{
+    static const struct
+    {
+        unsigned char bit;
+        const char*   name;
+    } kFlags[] = {
+        {0x02, "SYN"}, {0x10, "ACK"}, {0x01, "FIN"}, {0x04, "RST"}, {0x08, "PSH"}, {0x20, "URG"},
+    };
+    if (n == 0)
+        return;
+    size_t pos   = 0;
+    bool   first = true;
+    for (const auto& f : kFlags)
+    {
+        if (!(flags & f.bit))
+            continue;
+        const char* sep = first ? "[" : ", ";
+        pos += static_cast<size_t>(std::snprintf(out + pos, pos < n ? n - pos : 0, "%s%s", sep,
+                                                  f.name));
+        first = false;
+    }
+    if (first) // 一个 flag 都没有
+    {
+        out[0] = '\0';
+        return;
+    }
+    if (pos < n - 1)
+    {
+        out[pos++] = ']';
+        out[pos]   = '\0';
+    }
+    else
+        out[n - 1] = '\0';
+}
+
+// ---- 上层服务识别（据端口）----
+const char* serviceForPort(uint16_t port, bool udp)
+{
+    if (udp)
+    {
+        if (port == 53) return "DNS";
+        if (port == 123) return "NTP";
+        if (port == 67 || port == 68) return "DHCP";
+        if (port == 137 || port == 138) return "NetBIOS";
+        if (port == 5353) return "MDNS";
+        if (port == 1900) return "SSDP";
+        if (port == 443) return "QUIC";
+    }
+    else
+    {
+        if (port == 80 || port == 8080) return "HTTP";
+        if (port == 443 || port == 8443) return "TLS";
+        if (port == 22) return "SSH";
+        if (port == 53) return "TCP-DNS";
+        if (port == 21) return "FTP";
+        if (port == 25 || port == 587) return "SMTP";
+        if (port == 110) return "POP";
+        if (port == 143 || port == 993) return "IMAP";
+        if (port == 3306) return "MySQL";
+        if (port == 6379) return "Redis";
+        if (port == 27017) return "MongoDB";
+    }
+    return nullptr;
+}
+
+// ---- DNS 辅助 ----
+// 解析 DNS 名字（标签序列；遇压缩指针 0xC0 停止并返回消费字节数）
+std::string dnsNameAt(const unsigned char* p, uint32_t avail, uint32_t& consumed)
+{
+    std::string name;
+    uint32_t    pos = 0;
+    while (pos < avail)
+    {
+        uint8_t len = p[pos];
+        if (len == 0)
+        {
+            ++pos;
+            break;
+        }
+        if ((len & 0xC0) == 0xC0)
+        {
+            pos += 2; // 压缩指针：不跟随
+            break;
+        }
+        ++pos;
+        if (pos + len > avail)
+            break;
+        if (!name.empty())
+            name += '.';
+        for (uint32_t i = 0; i < len; ++i)
+            name += static_cast<char>(p[pos + i]);
+        pos += len;
+    }
+    consumed = pos;
+    return name;
+}
+
+const char* dnsTypeName(uint16_t t)
+{
+    switch (t)
+    {
+    case 1: return "A";
+    case 2: return "NS";
+    case 5: return "CNAME";
+    case 6: return "SOA";
+    case 12: return "PTR";
+    case 15: return "MX";
+    case 16: return "TXT";
+    case 28: return "AAAA";
+    case 33: return "SRV";
+    case 255: return "ANY";
+    default: return "?";
+    }
+}
+
+// 提取 DNS 报文第 0 个 question 的 name 与 qtype（消费 name 后的偏移回填）
+std::string dnsFirstQuestion(const unsigned char* payload, uint32_t len, uint16_t& qtype)
+{
+    qtype = 0;
+    if (len < 12)
+        return std::string();
+    uint16_t qd = rd16(payload + 4);
+    if (qd == 0)
+        return std::string();
+    uint32_t off = 12;
+    uint32_t consumed = 0;
+    std::string name = dnsNameAt(payload + 12, len - 12, consumed);
+    off += consumed;
+    if (off + 4 <= len)
+        qtype = rd16(payload + off);
+    return name;
+}
+
+// DNS 响应：摘要前几个回答记录（type + rdata）
+std::string dnsAnswerSummary(const unsigned char* payload, uint32_t len)
+{
+    std::string out;
+    if (len < 12)
+        return out;
+    uint16_t qd    = rd16(payload + 4);
+    uint16_t an    = rd16(payload + 6);
+    uint16_t anMax = an > 3 ? 3 : an; // 只摘要前 3 个，避免超长
+    if (an == 0)
+        return out;
+    uint32_t off = 12;
+    // 跳过 questions
+    for (uint16_t i = 0; i < qd; ++i)
+    {
+        if (off >= len)
+            return out;
+        uint32_t consumed = 0;
+        dnsNameAt(payload + off, len - off, consumed);
+        off += consumed + 4; // qtype + qclass
+    }
+    // 解析 answers
+    for (uint16_t i = 0; i < an && i < anMax; ++i)
+    {
+        if (off + 10 > len)
+            break;
+        uint32_t consumed = 0;
+        dnsNameAt(payload + off, len - off, consumed);
+        off += consumed;
+        if (off + 10 > len)
+            break;
+        uint16_t type    = rd16(payload + off);
+        uint16_t rdlen   = rd16(payload + off + 8);
+        const unsigned char* rdata = payload + off + 10;
+        if (off + 10 + rdlen > len)
+            break;
+        char buf[96];
+        if (type == 1 && rdlen == 4) // A
+        {
+            std::snprintf(buf, sizeof(buf), "%s %s", dnsTypeName(type),
+                          ipv4ToStr(rdata).c_str());
+        }
+        else if (type == 28 && rdlen == 16) // AAAA
+        {
+            std::snprintf(buf, sizeof(buf), "%s %s", dnsTypeName(type), ipv6ToStr(rdata).c_str());
+        }
+        else if ((type == 12 || type == 5 || type == 2) && rdlen > 0) // PTR/CNAME/NS
+        {
+            uint32_t c = 0;
+            std::string n = dnsNameAt(rdata, rdlen, c);
+            std::snprintf(buf, sizeof(buf), "%s %s", dnsTypeName(type), n.c_str());
+        }
+        else if (type == 16 && rdlen > 0) // TXT
+        {
+            std::string txt(reinterpret_cast<const char*>(rdata + 1),
+                            static_cast<size_t>(rdlen > 1 ? rdlen - 1 : 0));
+            if (txt.size() > 24)
+                txt.resize(24);
+            std::snprintf(buf, sizeof(buf), "TXT \"%s\"", txt.c_str());
+        }
+        else
+        {
+            std::snprintf(buf, sizeof(buf), "%s", dnsTypeName(type));
+        }
+        if (!out.empty())
+            out += ", ";
+        out += buf;
+        off += 10 + rdlen;
+    }
+    return out;
+}
+
+// DNS 报文 → info 摘要（查询 + 响应回答）
+std::string dnsInfo(const unsigned char* payload, uint32_t len, ProtocolDetail& detail)
+{
+    if (len < 12)
+        return std::string();
+    uint16_t id     = rd16(payload);
+    uint16_t flags  = rd16(payload + 2);
+    bool     resp   = (flags & 0x8000) != 0;
+    uint16_t qtype  = 0;
+    std::string name = dnsFirstQuestion(payload, len, qtype);
+    std::string answers = dnsAnswerSummary(payload, len);
+    detail.dnsAnswers = answers;
+
+    char buf[256];
+    if (resp)
+    {
+        if (!answers.empty())
+            std::snprintf(buf, sizeof(buf), "Standard query response 0x%04x, %s", id,
+                          answers.c_str());
+        else
+            std::snprintf(buf, sizeof(buf), "Standard query response 0x%04x", id);
+    }
+    else if (!name.empty())
+        std::snprintf(buf, sizeof(buf), "Standard query 0x%04x %s %s", id, dnsTypeName(qtype),
+                      name.c_str());
+    else
+        std::snprintf(buf, sizeof(buf), "Standard query 0x%04x", id);
+    return std::string(buf);
+}
+
+// ---- HTTP ----
+void parseHttp(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    // 只解析首行 + Host 头（TCP 载荷可能跨包，取首个完整 \r\n 行）
+    detail.http = true;
+    const unsigned char* lineEnd = static_cast<const unsigned char*>(
+        std::memchr(payload, '\n', len));
+    uint32_t lineLen = lineEnd ? static_cast<uint32_t>(lineEnd - payload) : len;
+    std::string firstLine(reinterpret_cast<const char*>(payload),
+                          static_cast<size_t>(lineLen > 0 && payload[lineLen - 1] == '\r'
+                                                  ? lineLen - 1
+                                                  : lineLen));
+    // 行首三 token（响应 "HTTP/1.1 200 OK" / 请求 "GET /x HTTP/1.1"）；手动切分省去 istringstream 开销。
+    std::string tok1, tok2, tok3;
+    {
+        std::string* toks[3] = {&tok1, &tok2, &tok3};
+        size_t       i = 0, n = firstLine.size(), t = 0;
+        while (t < 3)
+        {
+            while (i < n && (firstLine[i] == ' ' || firstLine[i] == '\t'))
+                ++i;
+            if (i >= n)
+                break;
+            size_t s = i;
+            while (i < n && firstLine[i] != ' ' && firstLine[i] != '\t')
+                ++i;
+            toks[t++]->assign(firstLine, s, i - s);
+        }
+    }
+    if (tok1.compare(0, 5, "HTTP/") == 0) // 响应行：HTTP/x.y CODE REASON
+    {
+        detail.httpVersion = tok1;
+        detail.httpStatus  = tok2;
+        detail.httpReason  = tok3;
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "%s %s %s", tok1.c_str(), tok2.c_str(), tok3.c_str());
+        packet.info = buf;
+    }
+    else if (tok2.compare(0, 1, "/") == 0 || tok2.compare(0, 1, "?") == 0)
+    {
+        detail.httpMethod  = tok1;
+        detail.httpUri     = tok2;
+        detail.httpVersion = tok3;
+        // 找 Host 头（前几行内）
+        const unsigned char* p = payload;
+        const unsigned char* end = payload + len;
+        for (int i = 0; i < 20 && p < end; ++i)
+        {
+            const unsigned char* nl = static_cast<const unsigned char*>(
+                std::memchr(p, '\n', static_cast<size_t>(end - p)));
+            if (!nl)
+                break;
+            size_t hlen = static_cast<size_t>(nl - p);
+            if (hlen > 2 && std::strncmp(reinterpret_cast<const char*>(p), "Host:", 5) == 0)
+            {
+                std::string host(reinterpret_cast<const char*>(p + 5), hlen - 5);
+                size_t s = host.find_first_not_of(" \t\r");
+                if (s != std::string::npos)
+                    detail.httpHost = host.substr(s);
+                break;
+            }
+            p = nl + 1;
+        }
+        char buf[256];
+        if (!detail.httpHost.empty())
+            std::snprintf(buf, sizeof(buf), "%s %s %s Host: %s", tok1.c_str(), tok2.c_str(),
+                          tok3.c_str(), detail.httpHost.c_str());
+        else
+            std::snprintf(buf, sizeof(buf), "%s %s %s", tok1.c_str(), tok2.c_str(),
+                          tok3.c_str());
+        packet.info = buf;
+    }
+}
+
+// ---- TLS ----
+// TLS record: type(1) version(2) len(2) payload
+void parseTls(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (len < 5)
+        return;
+    detail.tls = true;
+    unsigned char rtype = payload[0];
+    uint16_t      ver   = rd16(payload + 1);
+    uint16_t      rlen  = rd16(payload + 3);
+    const char*   version = nullptr;
+    if (ver == 0x0301) version = "TLS 1.0";
+    else if (ver == 0x0302) version = "TLS 1.1";
+    else if (ver == 0x0303) version = "TLS 1.2";
+    else if (ver == 0x0304) version = "TLS 1.3";
+    if (version)
+        detail.tlsVersion = version;
+
+    if (rtype == 0x16) // Handshake
+    {
+        if (len < 6)
+            return;
+        unsigned char hsType = payload[5];
+        const char*   hsName = nullptr;
+        switch (hsType)
+        {
+        case 1: hsName = "Client Hello"; break;
+        case 2: hsName = "Server Hello"; break;
+        case 4: hsName = "New Session Ticket"; break;
+        case 11: hsName = "Certificate"; break;
+        case 13: hsName = "Certificate Request"; break;
+        case 14: hsName = "Server Hello Done"; break;
+        case 15: hsName = "Certificate Verify"; break;
+        case 16: hsName = "Client Key Exchange"; break;
+        case 20: hsName = "Finished"; break;
+        default: hsName = "Handshake"; break;
+        }
+        detail.tlsType = hsName;
+        // ClientHello（type 1）里提取 SNI
+            if (hsType == 1 && len >= 12)
+            {
+                // body: version(2) random(32) sidLen(1)+sid cipherLen(2)+ciphers compLen(1)+comp extLen(2)+ext
+                uint32_t off = 5 + 4 + 2 + 32; // record 5 + hs 4 + version 2 + random 32 = 43
+                if (off < len)
+                {
+                    uint8_t sidLen = payload[off++];
+                    off += sidLen;
+                    if (off + 2 <= len)
+                    {
+                        uint16_t csLen = rd16(payload + off);
+                        off += 2 + csLen;
+                    }
+                    if (off < len)
+                    {
+                        uint8_t compLen = payload[off++];
+                        off += compLen;
+                    }
+                    if (off + 2 <= len)
+                    {
+                        uint16_t extTotal = rd16(payload + off);
+                        off += 2;
+                        uint32_t extEnd = off + extTotal;
+                        if (extEnd > len)
+                            extEnd = len;
+                        while (off + 4 <= extEnd)
+                        {
+                            uint16_t extType = rd16(payload + off);
+                            uint16_t extLen  = rd16(payload + off + 2);
+                            if (extType == 0 && extLen >= 5 && off + 4 + extLen <= extEnd)
+                            {
+                                // SNI 扩展布局：listLen(2) nameType(1) nameLen(2) name；extLen = 2 + listLen
+                                uint16_t listLen = rd16(payload + off + 4);
+                                if (listLen >= 3 && 2 + listLen <= extLen)
+                                {
+                                    uint16_t nameLen = rd16(payload + off + 4 + 3);
+                                    if (nameLen > 0 && 2 + 3 + nameLen <= extLen)
+                                    {
+                                        detail.tlsSni =
+                                            std::string(reinterpret_cast<const char*>(payload +
+                                                                                      off + 4 +
+                                                                                      3 + 2),
+                                                        nameLen);
+                                    }
+                                }
+                                break;
+                            }
+                            off += 4 + extLen;
+                        }
+                    }
+                }
+            }
+        }
+    else if (rtype == 0x17)
+    {
+        detail.tlsType = "Application Data";
+    }
+    else if (rtype == 0x15)
+    {
+        detail.tlsType = "Alert";
+    }
+    else if (rtype == 0x14)
+    {
+        detail.tlsType = "Change Cipher Spec";
+    }
+    char buf[128];
+    if (!detail.tlsSni.empty())
+        std::snprintf(buf, sizeof(buf), "%s, %s, SNI=%s", detail.tlsType.c_str(),
+                      version ? version : "TLS", detail.tlsSni.c_str());
+    else
+        std::snprintf(buf, sizeof(buf), "%s, %s", detail.tlsType.c_str(),
+                      version ? version : "TLS");
+    packet.info = buf;
+}
+
+// ---- DHCP ----
+void parseDhcp(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (len < 240)
+        return;
+    detail.dhcp = true;
+    uint8_t op = payload[0]; // 1=request 2=reply
+    // magic cookie 0x63825363 在偏移 236
+    if (payload[236] != 0x63 || payload[237] != 0x82 || payload[238] != 0x53 ||
+        payload[239] != 0x63)
+        return;
+    const char* type = "?";
+    uint32_t    off  = 240;
+    uint32_t    end  = len - 1; // 末尾 0xff 是 end option
+    while (off < end)
+    {
+        uint8_t opt = payload[off];
+        if (opt == 255)
+            break;
+        if (opt == 0) // pad
+        {
+            ++off;
+            continue;
+        }
+        if (off + 1 >= len)
+            break;
+        uint8_t olen = payload[off + 1];
+        if (opt == 53 && olen == 1 && off + 2 < len)
+        {
+            switch (payload[off + 2])
+            {
+            case 1: type = "Discover"; break;
+            case 2: type = "Offer"; break;
+            case 3: type = "Request"; break;
+            case 4: type = "Decline"; break;
+            case 5: type = "ACK"; break;
+            case 6: type = "NAK"; break;
+            case 7: type = "Release"; break;
+            case 8: type = "Inform"; break;
+            }
+            break;
+        }
+        off += 2 + olen;
+    }
+    detail.dhcpType = type;
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "DHCP %s, %s, XID=0x%08x", type,
+                  op == 2 ? "Reply" : "Request",
+                  rd32(payload + 4));
+    packet.info = buf;
+}
+
+// ---- NTP ----
+void parseNtp(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (len < 4)
+        return;
+    detail.ntp      = true;
+    uint8_t  b0     = payload[0];
+    unsigned vn     = (b0 >> 3) & 0x07;
+    unsigned mode   = b0 & 0x07;
+    const char* modeName = "?";
+    switch (mode)
+    {
+    case 3: modeName = "client"; break;
+    case 4: modeName = "server"; break;
+    case 6: modeName = "control"; break;
+    default: break;
+    }
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "NTP v%u, %s", vn, modeName);
+    detail.ntpDesc = buf;
+    packet.info    = buf;
+}
+
+// ---- TCP/UDP ----
+void parseTcp(const unsigned char* data, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (len < 4)
+        return;
+    packet.src_port = rd16(data);
+    packet.dst_port = rd16(data + 2);
+    packet.transport = "TCP";
+    const char* svc = serviceForPort(packet.src_port, false);
+    if (!svc)
+        svc = serviceForPort(packet.dst_port, false);
+    if (svc && std::strcmp(svc, "TCP-DNS") != 0)
+        packet.protocol = svc;
+    else
+        packet.protocol = "TCP";
+    unsigned char flags = (len >= 14) ? data[13] : 0;
+    uint32_t      seq = (len >= 8) ? rd32(data + 4) : 0;
+    uint32_t      ack = (len >= 12) ? rd32(data + 8) : 0;
+    uint16_t      win = (len >= 16) ? rd16(data + 14) : 0;
+    uint32_t      tcpLen = (len >= 12) ? ((data[12] >> 4) * 4) : 20;
+    uint32_t      appLen = (len > tcpLen) ? (len - tcpLen) : 0;
+
+    // 应用层解析（载荷非空且是已识别服务）
+    const unsigned char* app = data + tcpLen;
+    if (appLen > 0 && packet.protocol == "HTTP")
+        parseHttp(app, appLen, packet, detail);
+    else if (appLen > 0 && packet.protocol == "TLS")
+        parseTls(app, appLen, packet, detail);
+
+    if (detail.http || detail.tls)
+        return; // 应用层已填 info
+
+    char flagsBuf[40];
+    tcpFlagsToBuf(flagsBuf, sizeof(flagsBuf), flags);
+    char buf[160];
+    std::snprintf(buf, sizeof(buf), "%u \xe2\x86\x92 %u %s Seq=%u Ack=%u Win=%u Len=%u",
+                  packet.src_port, packet.dst_port, flagsBuf, seq, ack, win, appLen);
+    packet.info = buf;
+}
+
+void parseUdp(const unsigned char* data, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (len < 8)
+        return;
+    packet.src_port  = rd16(data);
+    packet.dst_port  = rd16(data + 2);
+    uint16_t udpLen  = rd16(data + 4);
+    packet.transport = "UDP";
+    const char* svc = serviceForPort(packet.src_port, true);
+    if (!svc)
+        svc = serviceForPort(packet.dst_port, true);
+    if (svc)
+        packet.protocol = svc;
+    else
+        packet.protocol = "UDP";
+
+    uint32_t appLen = (udpLen >= 8 && udpLen <= len) ? (udpLen - 8) : (len - 8);
+    const unsigned char* app = data + 8;
+
+    if (packet.protocol == "DNS" && appLen > 0)
+    {
+        packet.info = dnsInfo(app, appLen, detail);
+        if (packet.info.empty())
+        {
+            char buf[48];
+            std::snprintf(buf, sizeof(buf), "%u \xe2\x86\x92 %u Len=%u", packet.src_port,
+                          packet.dst_port, appLen);
+            packet.info = buf;
+        }
+        return;
+    }
+    if (packet.protocol == "DHCP" && appLen > 0)
+    {
+        parseDhcp(app, appLen, packet, detail);
+        return;
+    }
+    if (packet.protocol == "NTP" && appLen > 0)
+    {
+        parseNtp(app, appLen, packet, detail);
+        return;
+    }
+    char buf[48];
+    std::snprintf(buf, sizeof(buf), "%u \xe2\x86\x92 %u Len=%u", packet.src_port, packet.dst_port,
+                  appLen);
+    packet.info = buf;
+}
+
+void parseIcmp(const unsigned char* data, uint32_t len, Packet& packet, bool v6,
+               ProtocolDetail& detail)
+{
+    if (len < 4)
+        return;
+    packet.protocol = v6 ? "ICMPv6" : "ICMP";
+    uint8_t type = data[0];
+    uint8_t code = data[1];
+    const char* desc = nullptr;
+    if (!v6)
+    {
+        switch (type)
+        {
+        case 0: desc = "Echo (ping) reply"; break;
+        case 3: desc = "Destination unreachable"; break;
+        case 5: desc = "Redirect"; break;
+        case 8: desc = "Echo (ping) request"; break;
+        case 9: desc = "Router advertisement"; break;
+        case 10: desc = "Router solicitation"; break;
+        case 11: desc = "Time-to-live exceeded"; break;
+        case 13: desc = "Timestamp request"; break;
+        case 14: desc = "Timestamp reply"; break;
+        default: break;
+        }
+    }
+    else
+    {
+        switch (type)
+        {
+        case 1: desc = "Destination unreachable"; break;
+        case 2: desc = "Packet too big"; break;
+        case 3: desc = "Time exceeded"; break;
+        case 128: desc = "Echo (ping) request"; break;
+        case 129: desc = "Echo (ping) reply"; break;
+        case 133: desc = "Router solicitation"; break;
+        case 134: desc = "Router advertisement"; break;
+        case 135: desc = "Neighbor solicitation"; break;
+        case 136: desc = "Neighbor advertisement"; break;
+        case 137: desc = "Redirect"; break;
+        default: break;
+        }
+    }
+    char buf[80];
+    if (desc)
+        std::snprintf(buf, sizeof(buf), "%s (type=%u, code=%u)", desc, type, code);
+    else
+        std::snprintf(buf, sizeof(buf), "Type %u, code %u", type, code);
+    packet.info = buf;
+}
+
+void parseArp(const unsigned char* data, uint32_t len, Packet& packet)
+{
+    if (len < 28)
+        return;
+    uint16_t htype = rd16(data);
+    uint16_t ptype = rd16(data + 2);
+    uint16_t op    = rd16(data + 6);
+    packet.protocol = "ARP";
+    if (htype != 1 || ptype != 0x0800)
+        return;
+    if (op == 1)
+    {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "Who has %s? Tell %s", ipv4ToStr(data + 24).c_str(),
+                      ipv4ToStr(data + 14).c_str());
+        packet.info = buf;
+    }
+    else if (op == 2)
+    {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "%s is at %s", ipv4ToStr(data + 14).c_str(),
+                      macToStr(data + 8).c_str());
+        packet.info = buf;
+    }
+}
+
+// 解析 IPv4（含分片信息）
+bool parseIpv4(const unsigned char* data, uint32_t len, Packet& packet, uint8_t& proto,
+               const unsigned char*& payload, uint32_t& payloadLen, ProtocolDetail& detail)
+{
+    if (len < 20)
+        return false;
+    uint8_t  ihl = (data[0] & 0x0F) * 4;
+    uint16_t total = rd16(data + 2);
+    if (ihl < 20 || ihl > len)
+        return false;
+    proto     = data[9];
+    packet.src_ip = ipv4ToStr(data + 12);
+    packet.dst_ip = ipv4ToStr(data + 16);
+    // 分片：flags(2 字节) 的 MF=0x2000，offset 低 13 位
+    uint16_t fragField = rd16(data + 6);
+    detail.fragMore    = (fragField & 0x2000) != 0;
+    detail.fragOffset  = static_cast<uint16_t>((fragField & 0x1FFF) * 8);
+    detail.ipFragmented = (fragField & 0x1FFF) != 0 || detail.fragMore;
+    uint32_t plen = (total >= ihl && total <= len) ? (total - ihl) : (len - ihl);
+    payload    = data + ihl;
+    payloadLen = plen;
+    return true;
+}
+
+bool parseIpv6(const unsigned char* data, uint32_t len, Packet& packet, uint8_t& proto,
+               const unsigned char*& payload, uint32_t& payloadLen)
+{
+    if (len < 40)
+        return false;
+    uint16_t plen = rd16(data + 4);
+    proto     = data[6];
+    packet.src_ip = ipv6ToStr(data + 8);
+    packet.dst_ip = ipv6ToStr(data + 24);
+    uint32_t off = 40;
+    uint32_t avail = (plen + 40 <= len) ? plen : (len - 40);
+    int guard = 0;
+    while ((proto == 0 || proto == 43 || proto == 44 || proto == 51 || proto == 60) &&
+           guard++ < 8)
+    {
+        if (off + 2 > len)
+            break;
+        uint8_t next  = data[off];
+        uint8_t hlen8 = data[off + 1];
+        if (proto == 44)
+        {
+            if (off + 8 > len)
+                break;
+            off += 8;
+        }
+        else if (proto == 51)
+        {
+            off += (hlen8 + 2) * 4;
+        }
+        else
+        {
+            off += (hlen8 + 1) * 8;
+        }
+        proto = next;
+        if (off > len)
+            break;
+    }
+    if (off > avail + 40 || off > len)
+    {
+        payload    = nullptr;
+        payloadLen = 0;
+        return true;
+    }
+    payload    = data + off;
+    payloadLen = avail + 40 - off;
+    if (payloadLen > len - off)
+        payloadLen = len - off;
+    return true;
+}
+
+// 以太网帧解析
+bool parseEthernet(const unsigned char* data, uint32_t len, Packet& packet,
+                   const unsigned char*& payload, uint32_t& payloadLen, uint16_t& ethertype)
+{
+    if (len < 14)
+        return false;
+    packet.dst_mac = macToStr(data);
+    packet.src_mac = macToStr(data + 6);
+    uint32_t off = 14;
+    ethertype     = rd16(data + 12);
+    int guard = 0;
+    while ((ethertype == 0x8100 || ethertype == 0x88a8 || ethertype == 0x9100) && guard++ < 4)
+    {
+        if (off + 4 > len)
+            return false;
+        off += 4;
+        ethertype = rd16(data + off - 2);
+    }
+    if (off > len)
+        return false;
+    payload    = data + off;
+    payloadLen = len - off;
+    return true;
+}
+
+// 按 EtherType 分派到网络层/上层解析。Ethernet 与 Linux SLL/SLL2 剥掉各自的
+// 链路头后，携带的 EtherType 语义一致，故共用这段分派逻辑。
+bool dispatchByEtherType(uint16_t ethertype, const unsigned char* payload, uint32_t payloadLen,
+                         Packet& packet, ProtocolDetail& detail)
+{
+    if (ethertype == 0x0806)
+    {
+        parseArp(payload, payloadLen, packet);
+        return true;
+    }
+    if (ethertype == 0x0800)
+    {
+        uint8_t proto = 0;
+        if (!parseIpv4(payload, payloadLen, packet, proto, payload, payloadLen, detail))
+            return false;
+        if (proto == 6)
+            parseTcp(payload, payloadLen, packet, detail);
+        else if (proto == 17)
+            parseUdp(payload, payloadLen, packet, detail);
+        else if (proto == 1)
+            parseIcmp(payload, payloadLen, packet, false, detail);
+        else if (proto == 2)
+        {
+            packet.protocol = "IGMP";
+            packet.info     = "IGMP";
+        }
+        else
+        {
+            char buf[16];
+            std::snprintf(buf, sizeof(buf), "IP-%u", proto);
+            packet.protocol = buf;
+        }
+        return true;
+    }
+    if (ethertype == 0x86DD)
+    {
+        uint8_t proto = 0;
+        if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen))
+            return false;
+        if (proto == 6)
+            parseTcp(payload, payloadLen, packet, detail);
+        else if (proto == 17)
+            parseUdp(payload, payloadLen, packet, detail);
+        else if (proto == 58)
+            parseIcmp(payload, payloadLen, packet, true, detail);
+        else if (proto == 59)
+            return true;
+        else
+        {
+            char buf[16];
+            std::snprintf(buf, sizeof(buf), "IPv6-%u", proto);
+            packet.protocol = buf;
+        }
+        return true;
+    }
+    if (ethertype == 0x88CC)
+    {
+        packet.protocol = "LLDP";
+        packet.info     = "Link Layer Discovery Protocol";
+        return true;
+    }
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "0x%04x", ethertype);
+    packet.protocol = buf;
+    packet.info     = "Unknown ethertype " + std::string(buf);
+    return true;
+}
+
+// Linux "cooked" 捕获（tcpdump -i any）：
+//   SLL  (linktype 113)：pkttype(2) arphrd(2) lladdrlen(2) lladdr(8) protocol(2) → 头长 16
+//   SLL2 (linktype 276)：protocol(2) reserved(2) ifindex(4) arphrd(2) pkttype(1) lladdrlen(1)
+//                        lladdr(8) → 头长 20，protocol 在最前
+bool parseSll(const unsigned char* data, uint32_t len, bool v2, Packet& packet,
+              ProtocolDetail& detail)
+{
+    uint32_t hdr = v2 ? 20 : 16;
+    if (len < hdr)
+        return false;
+    uint16_t ethertype = v2 ? rd16(data) : rd16(data + 14);
+    return dispatchByEtherType(ethertype, data + hdr, len - hdr, packet, detail);
+}
+
+// 主解析：填充 Packet + ProtocolDetail
+bool parseFrameCtx(const unsigned char* data, uint32_t len, int linkType, Packet& packet,
+                   ProtocolDetail& detail)
+{
+    if (!data || len < 14)
+        return false;
+
+    // NULL/Loopback 链路（BSD lo 接口）
+    if (linkType == 0 ||
+        (linkType < 0 && len >= 4 &&
+         ((data[0] == 2 && data[1] == 0 && data[2] == 0 && data[3] == 0) ||
+          (data[0] == 30 && data[1] == 0 && data[2] == 0 && data[3] == 0) ||
+          (data[0] == 24 && data[1] == 0 && data[2] == 0 && data[3] == 0))))
+    {
+        uint32_t family = static_cast<uint32_t>(data[0]) |
+                          (static_cast<uint32_t>(data[1]) << 8) |
+                          (static_cast<uint32_t>(data[2]) << 16) |
+                          (static_cast<uint32_t>(data[3]) << 24);
+        const unsigned char* payload    = data + 4;
+        uint32_t             payloadLen = len - 4;
+        if (family == 2)
+        {
+            uint8_t proto = 0;
+            if (!parseIpv4(payload, payloadLen, packet, proto, payload, payloadLen, detail))
+                return false;
+            if (proto == 6)
+                parseTcp(payload, payloadLen, packet, detail);
+            else if (proto == 17)
+                parseUdp(payload, payloadLen, packet, detail);
+            else if (proto == 1)
+                parseIcmp(payload, payloadLen, packet, false, detail);
+            else
+            {
+                char buf[16];
+                std::snprintf(buf, sizeof(buf), "IP-%u", proto);
+                packet.protocol = buf;
+            }
+            return true;
+        }
+        if (family == 30 || family == 24)
+        {
+            uint8_t proto = 0;
+            if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen))
+                return false;
+            if (proto == 6)
+                parseTcp(payload, payloadLen, packet, detail);
+            else if (proto == 17)
+                parseUdp(payload, payloadLen, packet, detail);
+            else if (proto == 58)
+                parseIcmp(payload, payloadLen, packet, true, detail);
+            else
+            {
+                char buf[16];
+                std::snprintf(buf, sizeof(buf), "IPv6-%u", proto);
+                packet.protocol = buf;
+            }
+            return true;
+        }
+    }
+
+    // Linux SLL / SLL2（tcpdump -i any 抓包的链路层）
+    if (linkType == 113)
+        return parseSll(data, len, false, packet, detail);
+    if (linkType == 276)
+        return parseSll(data, len, true, packet, detail);
+
+    // 默认 Ethernet II（含 VLAN/QinQ 剥离）
+    const unsigned char* payload    = nullptr;
+    uint32_t             payloadLen = 0;
+    uint16_t             ethertype  = 0;
+    if (!parseEthernet(data, len, packet, payload, payloadLen, ethertype))
+        return false;
+    return dispatchByEtherType(ethertype, payload, payloadLen, packet, detail);
+}
+} // namespace
+
+bool available()
+{
+    return true;
+}
+
+bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType)
+{
+    ProtocolDetail detail;
+    return parseFrameCtx(data, len, linkType, packet, detail);
+}
+
+// ---- 完整协议树 ----
+namespace
+{
+void addChild(DetailNode& parent, const std::string& label, const std::string& value)
+{
+    DetailNode n;
+    n.label = label;
+    n.value = value;
+    parent.children.push_back(n);
+}
+
+void addLeaf(const std::string& label, const std::string& value, DetailNode& root)
+{
+    addChild(root, label, value);
+}
+} // namespace
+
+bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint32_t frameNumber,
+                     DetailNode& root)
+{
+    Packet p;
+    ProtocolDetail detail;
+    if (!parseFrameCtx(data, len, linkType, p, detail))
+        return false;
+    p.frame_number = frameNumber;
+
+    root.label = "Frame " + std::to_string(frameNumber);
+    char buf[128];
+
+    // Ethernet II / Null/Loopback
+    DetailNode eth;
+    if (!p.src_mac.empty())
+    {
+        eth.label = "Ethernet II";
+        addChild(eth, "Destination", p.dst_mac);
+        addChild(eth, "Source", p.src_mac);
+        bool v6addr = p.src_ip.find(':') != std::string::npos;
+        addChild(eth, "Type", p.protocol + " (0x" + (v6addr ? "86dd" : "0800") + ")");
+    }
+    else
+    {
+        eth.label = "Null/Loopback";
+        addChild(eth, "Family", p.src_ip.find(':') != std::string::npos ? "IPv6" : "IPv4");
+    }
+    root.children.push_back(eth);
+
+    // IP 层
+    if (!p.src_ip.empty())
+    {
+        bool v6 = p.src_ip.find(':') != std::string::npos;
+        DetailNode ip;
+        ip.label = v6 ? "Internet Protocol Version 6" : "Internet Protocol Version 4";
+        addChild(ip, "Source", p.src_ip);
+        addChild(ip, "Destination", p.dst_ip);
+        addChild(ip, "Protocol", p.protocol);
+        if (detail.ipFragmented)
+        {
+            std::snprintf(buf, sizeof(buf), "%s (offset=%u)",
+                          detail.fragMore ? "More fragments" : "Last fragment",
+                          detail.fragOffset);
+            addChild(ip, "Fragment", buf);
+        }
+        root.children.push_back(ip);
+    }
+
+    // 传输层
+    if (p.transport == "TCP" || p.transport == "UDP")
+    {
+        DetailNode tr;
+        tr.label = (p.transport == "TCP") ? "Transmission Control Protocol"
+                                          : "User Datagram Protocol";
+        char pbuf[16];
+        std::snprintf(pbuf, sizeof(pbuf), "%u", p.src_port);
+        addChild(tr, "Source Port", pbuf);
+        std::snprintf(pbuf, sizeof(pbuf), "%u", p.dst_port);
+        addChild(tr, "Destination Port", pbuf);
+        addChild(tr, "Info", p.info);
+        root.children.push_back(tr);
+    }
+    else if (p.protocol == "ICMP" || p.protocol == "ICMPv6")
+    {
+        DetailNode ic;
+        ic.label = (p.protocol == "ICMPv6") ? "Internet Control Message Protocol v6"
+                                            : "Internet Control Message Protocol";
+        addChild(ic, "Info", p.info);
+        root.children.push_back(ic);
+    }
+    else if (p.protocol == "ARP")
+    {
+        DetailNode ar;
+        ar.label = "Address Resolution Protocol";
+        addChild(ar, "Info", p.info);
+        root.children.push_back(ar);
+    }
+
+    // 应用层分层
+    if (detail.http)
+    {
+        DetailNode hp;
+        hp.label = "Hypertext Transfer Protocol";
+        if (!detail.httpMethod.empty())
+            addChild(hp, "Method", detail.httpMethod);
+        if (!detail.httpUri.empty())
+            addChild(hp, "URI", detail.httpUri);
+        if (!detail.httpVersion.empty())
+            addChild(hp, "Version", detail.httpVersion);
+        if (!detail.httpStatus.empty())
+            addChild(hp, "Status Code", detail.httpStatus + " " + detail.httpReason);
+        if (!detail.httpHost.empty())
+            addChild(hp, "Host", detail.httpHost);
+        root.children.push_back(hp);
+    }
+    else if (detail.tls)
+    {
+        DetailNode tl;
+        tl.label = "Transport Layer Security";
+        addChild(tl, "Handshake", detail.tlsType);
+        if (!detail.tlsVersion.empty())
+            addChild(tl, "Version", detail.tlsVersion);
+        if (!detail.tlsSni.empty())
+            addChild(tl, "Server Name Indication", detail.tlsSni);
+        root.children.push_back(tl);
+    }
+    else if (p.protocol == "DNS")
+    {
+        DetailNode dn;
+        dn.label = "Domain Name System";
+        addChild(dn, "Info", p.info);
+        if (!detail.dnsAnswers.empty())
+            addChild(dn, "Answers", detail.dnsAnswers);
+        root.children.push_back(dn);
+    }
+    else if (detail.dhcp)
+    {
+        DetailNode dh;
+        dh.label = "Dynamic Host Configuration Protocol";
+        addChild(dh, "Message Type", detail.dhcpType);
+        addChild(dh, "Info", p.info);
+        root.children.push_back(dh);
+    }
+    else if (detail.ntp)
+    {
+        DetailNode nt;
+        nt.label = "Network Time Protocol";
+        addChild(nt, "Info", detail.ntpDesc);
+        root.children.push_back(nt);
+    }
+
+    return true;
+}
+
+// ---- 显示过滤子集 ----
+// 编译一次为 std::function 闭包求值树（Pred）：语法/字段校验在编译期完成，求值期只做比较，N 个报文只解析一次。
+// 文法（优先级 ! > && > ||，支持括号）：
+//   or     := and ("||" and)*
+//   and    := unary ("&&" unary)*
+//   unary  := "!" unary | "(" or ")" | primary
+//   primary:= FIELD (("=="|"!=") VALUE)?      // 带值=比较；裸字段=存在性
+namespace
+{
+typedef std::function<bool(const Packet&)> Pred;
+
+class Compiler
+{
+public:
+    Compiler(const std::string& s, std::string* e) : src(s), err(e), pos(0) {}
+
+    // 成功返回可复用谓词；语法/字段非法返回空 Pred 并置 *err。
+    Pred compile()
+    {
+        skipSpace();
+        Pred p = parseOr();
+        if (!p)
+            return Pred();
+        skipSpace();
+        if (pos != src.size())
+        {
+            setErr("unexpected trailing text");
+            return Pred();
+        }
+        return p;
+    }
+
+private:
+    const std::string& src;
+    std::string*       err;
+    size_t             pos;
+
+    void setErr(const std::string& m)
+    {
+        if (err && err->empty())
+            *err = "过滤表达式错误：" + m;
+    }
+
+    void skipSpace()
+    {
+        while (pos < src.size() && (src[pos] == ' ' || src[pos] == '\t'))
+            ++pos;
+    }
+
+    bool peek(const char* tok) { return src.compare(pos, std::strlen(tok), tok) == 0; }
+
+    Pred parseOr()
+    {
+        Pred left = parseAnd();
+        if (!left)
+            return Pred();
+        for (;;)
+        {
+            skipSpace();
+            if (!peek("||"))
+                break;
+            pos += 2;
+            Pred right = parseAnd();
+            if (!right)
+                return Pred();
+            Pred l = left, r = right; // 捕获两个子谓词，合成新的短路 OR
+            left = [l, r](const Packet& p) { return l(p) || r(p); };
+        }
+        return left;
+    }
+
+    Pred parseAnd()
+    {
+        Pred left = parseUnary();
+        if (!left)
+            return Pred();
+        for (;;)
+        {
+            skipSpace();
+            if (!peek("&&"))
+                break;
+            pos += 2;
+            Pred right = parseUnary();
+            if (!right)
+                return Pred();
+            Pred l = left, r = right;
+            left = [l, r](const Packet& p) { return l(p) && r(p); };
+        }
+        return left;
+    }
+
+    Pred parseUnary()
+    {
+        skipSpace();
+        if (peek("!") && !peek("!=")) // 逻辑非（勿把 "!=" 当成非）
+        {
+            pos += 1;
+            Pred inner = parseUnary();
+            if (!inner)
+                return Pred();
+            Pred i = inner;
+            return [i](const Packet& p) { return !i(p); };
+        }
+        if (peek("("))
+        {
+            pos += 1;
+            Pred r = parseOr();
+            if (!r)
+                return Pred();
+            skipSpace();
+            if (pos < src.size() && src[pos] == ')')
+                ++pos;
+            return r;
+        }
+        return parsePrimary();
+    }
+
+    Pred parsePrimary()
+    {
+        skipSpace();
+        size_t start = pos;
+        while (pos < src.size() && (std::isalnum(static_cast<unsigned char>(src[pos])) ||
+                                    src[pos] == '.' || src[pos] == '_' || src[pos] == '-'))
+            ++pos;
+        std::string field = src.substr(start, pos - start);
+        if (field.empty())
+        {
+            setErr("missing field");
+            return Pred();
+        }
+        skipSpace();
+        if (pos >= src.size() || (!peek("==") && !peek("!=")))
+            return makeExists(field);
+        bool negate = peek("!=");
+        pos += 2;
+        skipSpace();
+        size_t vstart = pos;
+        while (pos < src.size() && src[pos] != ' ' && src[pos] != '\t' && src[pos] != ')' &&
+               src[pos] != '&' && src[pos] != '|')
+            ++pos;
+        return makeCompare(field, src.substr(vstart, pos - vstart), negate);
+    }
+
+    // FIELD ==/!= VALUE：按字段编译成比较闭包（tcp/udp 端口含传输层类型校验）。未知字段→报错返回空。
+    Pred makeCompare(const std::string& field, const std::string& value, bool negate)
+    {
+        Pred eq;
+        if (field == "frame.number")
+        {
+            long v = std::strtol(value.c_str(), nullptr, 10);
+            eq = [v](const Packet& p) { return static_cast<long>(p.frame_number) == v; };
+        }
+        else if (field == "eth.addr")
+            eq = [value](const Packet& p) { return p.src_mac == value || p.dst_mac == value; };
+        else if (field == "eth.src")
+            eq = [value](const Packet& p) { return p.src_mac == value; };
+        else if (field == "eth.dst")
+            eq = [value](const Packet& p) { return p.dst_mac == value; };
+        else if (field == "ip.addr" || field == "ipv6.addr")
+            eq = [value](const Packet& p) { return p.src_ip == value || p.dst_ip == value; };
+        else if (field == "ip.src" || field == "ipv6.src")
+            eq = [value](const Packet& p) { return p.src_ip == value; };
+        else if (field == "ip.dst" || field == "ipv6.dst")
+            eq = [value](const Packet& p) { return p.dst_ip == value; };
+        else if (field == "tcp.port" || field == "udp.port")
+        {
+            std::string tp = (field.compare(0, 3, "tcp") == 0) ? "TCP" : "UDP";
+            long        v  = std::strtol(value.c_str(), nullptr, 10);
+            eq             = [tp, v](const Packet& p) {
+                return p.transport == tp && (p.src_port == v || p.dst_port == v);
+            };
+        }
+        else if (field == "tcp.srcport" || field == "udp.srcport")
+        {
+            std::string tp = (field.compare(0, 3, "tcp") == 0) ? "TCP" : "UDP";
+            long        v  = std::strtol(value.c_str(), nullptr, 10);
+            eq = [tp, v](const Packet& p) { return p.transport == tp && p.src_port == v; };
+        }
+        else if (field == "tcp.dstport" || field == "udp.dstport")
+        {
+            std::string tp = (field.compare(0, 3, "tcp") == 0) ? "TCP" : "UDP";
+            long        v  = std::strtol(value.c_str(), nullptr, 10);
+            eq = [tp, v](const Packet& p) { return p.transport == tp && p.dst_port == v; };
+        }
+        else
+        {
+            setErr("unsupported field '" + field + "'");
+            return Pred();
+        }
+        if (negate)
+        {
+            Pred inner = eq;
+            return [inner](const Packet& p) { return !inner(p); };
+        }
+        return eq;
+    }
+
+    // 裸字段：协议/传输层存在性判断。未知字段→报错返回空。
+    Pred makeExists(const std::string& f)
+    {
+        if (f == "tcp") return [](const Packet& p) { return p.transport == "TCP"; };
+        if (f == "udp") return [](const Packet& p) { return p.transport == "UDP"; };
+        if (f == "arp") return [](const Packet& p) { return p.protocol == "ARP"; };
+        if (f == "icmp") return [](const Packet& p) { return p.protocol == "ICMP"; };
+        if (f == "icmpv6") return [](const Packet& p) { return p.protocol == "ICMPv6"; };
+        if (f == "dns") return [](const Packet& p) { return p.protocol == "DNS"; };
+        if (f == "http") return [](const Packet& p) { return p.protocol == "HTTP"; };
+        if (f == "tls" || f == "ssl") return [](const Packet& p) { return p.protocol == "TLS"; };
+        if (f == "ssh") return [](const Packet& p) { return p.protocol == "SSH"; };
+        if (f == "dhcp") return [](const Packet& p) { return p.protocol == "DHCP"; };
+        if (f == "ntp") return [](const Packet& p) { return p.protocol == "NTP"; };
+        if (f == "ip") return [](const Packet& p) { return !p.src_ip.empty(); };
+        if (f == "ipv6")
+            return [](const Packet& p) { return p.src_ip.find(':') != std::string::npos; };
+        setErr("unsupported field '" + f + "'");
+        return Pred();
+    }
+};
+} // namespace
+
+std::function<bool(const Packet&)> compileDisplayFilter(const std::string& expr, std::string* err)
+{
+    if (err)
+        err->clear();
+    if (expr.empty())
+    {
+        if (err)
+            *err = "过滤表达式为空";
+        return Pred();
+    }
+    Compiler c(expr, err);
+    return c.compile();
+}
+
+bool matchDisplayFilter(const std::string& expr, const Packet& packet, std::string* err)
+{
+    // 单包 API：编译后立即求值一次（大批量求值请用 compileDisplayFilter 复用谓词）。
+    std::function<bool(const Packet&)> pred = compileDisplayFilter(expr, err);
+    if (!pred)
+        return false;
+    return pred(packet);
+}
+} // namespace NativePacketParser

--- a/src/PacketParser.cpp
+++ b/src/PacketParser.cpp
@@ -6,8 +6,7 @@ namespace PacketParser
 {
 namespace
 {
-// [p,end) 内解析十进制整数；至少消费一个数字才算成功。
-// strtol 在 '\t'/'\0' 处自然停下，无需先把字段拷成独立字符串。
+// [p,end) 内解析十进制整数（strtol 在 '\t'/'\0' 处自然停下，无需拷贝字段）。
 bool parseLongField(const char* p, const char* end, long& out)
 {
     if (p >= end)
@@ -51,9 +50,8 @@ bool parseLine(const std::string& rawLine, Packet& packet)
         --lineLen;
     }
 
-    // 只记录各字段的 [start,end) 边界，不为 16 个字段预先各分配一个 string：
-    // 数字字段（0-3、10-13）就地解析用完即弃，只有要存进 Packet 的文本字段
-    // （4-9、14、15）才在最后 substr 出来。
+    // 只记录各字段的 [start,end) 边界，不为 16 个字段预先各分配 string：
+    // 数字字段就地解析用完即弃，只有要存进 Packet 的文本字段才在最后 substr 出来。
     struct Span
     {
         size_t start;
@@ -92,8 +90,7 @@ bool parseLine(const std::string& rawLine, Packet& packet)
     auto        substr  = [&](int i)
     { return rawLine.substr(spans[i].start, spans[i].end - spans[i].start); };
 
-    // 数字字段就地解析：任一必填数字字段非法（空/非数字）即整行失败，
-    // 不让异常沿 streamPackets 冒泡到 UI 线程。
+    // 数字字段就地解析：任一必填数字字段非法（空/非数字）即整行失败。
     long tmp = 0;
     if (!parseLongField(spanPtr(0), spanEnd(0), tmp))
     {
@@ -141,8 +138,7 @@ bool parseLine(const std::string& rawLine, Packet& packet)
     // IPv4 为空时回退到 IPv6 字段
     packet.src_ip = !isEmpty(6) ? substr(6) : substr(7);
     packet.dst_ip = !isEmpty(8) ? substr(8) : substr(9);
-    // 传输层：tcp.* 非空即 TCP，否则 udp.* 非空即 UDP。仅供会话视图区分，
-    // 不影响 src_port/dst_port（二者已合并取值）。
+    // 传输层：tcp.* 非空即 TCP，否则 udp.* 非空即 UDP；仅供会话视图区分，不影响端口取值。
     if (!isEmpty(10) || !isEmpty(12))
     {
         packet.transport = "TCP";

--- a/src/PcapAnalyzer.cpp
+++ b/src/PcapAnalyzer.cpp
@@ -16,6 +16,73 @@
 #include "tsharkCommand.hpp"
 #include "utils.hpp"
 
+namespace
+{
+// ---- pcapng 支持 ----
+// 嗅探格式：pcapng 的 SHB 首 4 字节为 0x0A0D0D0A；经典 pcap 为 a1b2c3d4 等。读前 4 字节区分。
+bool sniffIsPcapNg(const std::string& filePath)
+{
+    FILE* f = std::fopen(filePath.c_str(), "rb");
+    if (!f)
+        return false;
+    unsigned char magic[4] = {0};
+    size_t        n         = std::fread(magic, 1, 4, f);
+    std::fclose(f);
+    if (n < 4)
+        return false;
+    // 小端读 uint32：0x0A0D0D0A
+    return magic[0] == 0x0A && magic[1] == 0x0D && magic[2] == 0x0D && magic[3] == 0x0A;
+}
+
+// 读小端 uint32（pcapng 块内字段；tshark 输出为小端，大端文件罕见，暂不支持）
+uint32_t readLe32(const unsigned char* p)
+{
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// 预扫描 pcapng，返回各包 packet-data 在文件中的偏移（按帧号 0 基索引）。
+// 块布局：Block Type(4) + Total Length(4) + 载荷 + Total Length(4)，长度含首尾。
+std::vector<uint64_t> scanPcapNgPacketOffsets(const std::string& filePath)
+{
+    std::vector<uint64_t> offsets;
+    FILE* f = std::fopen(filePath.c_str(), "rb");
+    if (!f)
+        return offsets;
+
+    unsigned char hdr[8];
+    while (std::fread(hdr, 1, 8, f) == 8)
+    {
+        uint32_t type = readLe32(hdr);
+        uint32_t total = readLe32(hdr + 4);
+        if (total < 12)
+            break; // 损坏：块长不合法
+
+        if (type == 0x00000006) // EPB：接口ID(4)+tsHigh(4)+tsLow(4)+capLen(4)+origLen(4)，数据在块内偏移 28
+        {
+            uint64_t blockStart = 0;
+            // 块起始 = 当前位置 - 8（已读 8 字节头）
+            long long cur = std::ftell(f);
+            uint64_t blockStart64 = static_cast<uint64_t>(cur) - 8;
+            offsets.push_back(blockStart64 + 28);
+        }
+        else if (type == 0x00000003) // SPB：origLen(4) 后即数据，数据在块内偏移 12
+        {
+            long long cur = std::ftell(f);
+            uint64_t blockStart64 = static_cast<uint64_t>(cur) - 8;
+            offsets.push_back(blockStart64 + 12);
+        }
+        // 其他块（IDB/NRB/自定义）跳过
+
+        if (std::fseek(f, static_cast<long>(total) - 8, SEEK_CUR) != 0)
+            break; // 前进到下一块（已读 8 字节头）
+    }
+    std::fclose(f);
+    return offsets;
+}
+
+} // namespace
+
 PcapAnalyzer::PcapAnalyzer(const std::string& tsharkPath, const std::string& ip2RegionDbPath)
     : tsharkPath(tsharkPath), ip2RegionDbPath(ip2RegionDbPath)
 {
@@ -46,24 +113,38 @@ bool PcapAnalyzer::streamPackets(
 
     char buffer[4096];
 
-    // 当前处理的报文在文件中的偏移，第一个报文的偏移就是全局文件头24(也就是sizeof(PcapHeader))字节。
-    // 用 64 位累加，避免超过 4GB 的大 pcap 偏移溢出。
+    // pcapng 预扫描：tshark 输出帧序与文件内 EPB/SPB 顺序一致，按帧号索引到
+    // packet-data 偏移（取 hex 用）。经典 pcap 则按 24 字节头 + 记录头累加。
+    std::vector<uint64_t> ngOffsets;
+    bool                  isPcapNg = sniffIsPcapNg(filePath);
+    if (isPcapNg)
+        ngOffsets = scanPcapNgPacketOffsets(filePath);
+
+    // 当前报文在文件中的偏移，首包偏移即全局文件头 sizeof(PcapHeader) 字节；64 位累加避免大 pcap 溢出。
     uint64_t file_offset = sizeof(PcapHeader);
     while (fgets(buffer, sizeof(buffer), pipe) != nullptr)
     {
         std::shared_ptr<Packet> packet = std::make_shared<Packet>();
         if (!PacketParser::parseLine(buffer, *packet))
         {
-            // 解析失败会破坏后续报文的文件偏移累加，无法安全继续，直接终止本次分析。
-            // 不用 assert：release 构建下 assert 会被去除，等于漏掉这条错误路径。
+            // 解析失败会破坏后续偏移累加，无法安全继续，直接终止（不用 assert：release 会被去除）。
             LOG_F(ERROR, "解析 tshark 输出行失败，终止分析: %s", buffer);
             ProcessUtil::PcloseEx(pipe, tsharkPid);
             return false;
         }
 
-        // 记录本包偏移，再前移游标到下一包起始（包头 + 抓包长度）
-        packet->file_offset = file_offset + sizeof(PacketHeader);
-        file_offset         = file_offset + sizeof(PacketHeader) + packet->cap_len;
+        if (isPcapNg)
+        {
+            // 按帧号取预扫描偏移；越界时置 0，getPacketHexData 的越界检查会返回 false。
+            size_t idx = static_cast<size_t>(packet->frame_number) - 1;
+            packet->file_offset = (idx < ngOffsets.size()) ? ngOffsets[idx] : 0;
+        }
+        else
+        {
+            // 记录本包偏移，再前移游标到下一包起始（包头 + 抓包长度）
+            packet->file_offset = file_offset + sizeof(PacketHeader);
+            file_offset         = file_offset + sizeof(PacketHeader) + packet->cap_len;
+        }
 
         if (ip2RegionReady)
         {
@@ -90,8 +171,7 @@ bool PcapAnalyzer::analysisFile(const std::string& filePath)
 
     currentFilePath = filePath;
 
-    // 打开随机读取器一次，供后续 getPacketHexData 复用；失败不影响解析结果本身，
-    // 仅令取 hex 数据不可用（getPacketHexData 会因未打开而返回 false）。
+    // 打开随机读取器一次供 getPacketHexData 复用；失败仅令取 hex 不可用，不影响解析结果。
     if (!fileReader.open(filePath))
     {
         LOG_F(WARNING, "无法打开报文文件用于十六进制读取: %s", filePath.c_str());
@@ -133,8 +213,7 @@ bool PcapAnalyzer::analysisFile(const std::string& filePath,
 
 void PcapAnalyzer::processPacket(const std::shared_ptr<Packet>& packet)
 {
-    // tshark 的 frame_number 从 1 起、稠密递增，用 (帧号-1) 作下标直接落入连续内存：
-    // 顺序插入时等价于 push_back，省去 unordered_map 每包一次的哈希桶节点分配与哈希计算。
+    // frame_number 从 1 起、稠密递增，用 (帧号-1) 作下标落入连续内存，省去 map 的哈希开销。
     if (packet->frame_number <= 0)
     {
         return; // 帧号异常（理论上不会出现），无法映射到下标，跳过
@@ -142,8 +221,7 @@ void PcapAnalyzer::processPacket(const std::shared_ptr<Packet>& packet)
     size_t idx = static_cast<size_t>(packet->frame_number) - 1;
     if (idx >= allPackets.size())
     {
-        // 顺序到达时每次仅 +1；vector 的几何增长保证整体仍是摊还 O(1)。
-        // 若偶发乱序/空洞，留空槽也能保证按帧号随机访问不越界。
+        // 顺序到达等价 push_back，摊还 O(1)；偶发乱序留空槽也保证按帧号随机访问不越界。
         allPackets.resize(idx + 1);
     }
     allPackets[idx] = packet;
@@ -251,8 +329,7 @@ std::string attr(rapidxml::xml_node<>* node, const char* name)
     return a ? std::string(a->value(), a->value_size()) : std::string();
 }
 
-// 把一个 PDML 的 <proto>/<field> 节点递归转成 DetailNode：
-// label 优先用 showname（人类可读），回退到 name；value 优先 show，回退 value。
+// 把 PDML 的 <proto>/<field> 节点递归转成 DetailNode：label 用 showname 回退 name，value 用 show 回退 value。
 DetailNode pdmlNodeToDetail(rapidxml::xml_node<>* node)
 {
     DetailNode d;
@@ -332,43 +409,64 @@ bool PcapAnalyzer::getPacketDetailTree(uint32_t frameNumber, DetailNode& root)
 }
 
 bool PcapAnalyzer::getFramesByDisplayFilter(const std::string&     displayFilter,
-                                            std::vector<uint32_t>& frameNumbers)
+                                            std::vector<uint32_t>& frameNumbers,
+                                            std::string* errorOut)
 {
     frameNumbers.clear();
+    if (errorOut)
+        errorOut->clear();
     if (currentFilePath.empty())
     {
         LOG_F(ERROR, "尚未分析任何文件，无法执行显示过滤");
+        if (errorOut)
+            *errorOut = "尚未分析任何文件";
         return false;
     }
     if (displayFilter.empty())
     {
+        if (errorOut)
+            *errorOut = "过滤表达式为空";
         return false; // 空过滤：交由调用方走“不过滤”路径
     }
 
-    // 只取匹配帧号：-Y 过滤 + -T fields -e frame.number，逐行一个编号。
+    // 只取匹配帧号：-Y 过滤 + -T fields -e frame.number；mergeStderr 把 tshark 错误合并进管道以透传。
     std::vector<std::string> args = {tsharkPath,    "-r", currentFilePath,
                                      "-Y",          displayFilter,
                                      "-T",          "fields",
                                      "-e",          "frame.number"};
 
     ProcessUtil::ProcHandle tsharkPid = ProcessUtil::kInvalidProc;
-    FILE* pipe      = ProcessUtil::PopenEx(args, &tsharkPid, "r");
+    FILE* pipe = ProcessUtil::PopenEx(args, &tsharkPid, "r", /*mergeStderr=*/true);
     if (!pipe)
     {
         LOG_F(ERROR, "运行 tshark 执行显示过滤失败: %s", displayFilter.c_str());
+        if (errorOut)
+            *errorOut = "无法启动 tshark 执行过滤";
         return false;
     }
 
-    char buffer[256];
+    char   buffer[256];
+    bool   sawError = false; // stderr 合并后，错误行以 "tshark:" 等前缀出现
     while (fgets(buffer, sizeof(buffer), pipe) != nullptr)
     {
-        // 每行一个帧号，可能带前后空白；空行跳过，非法行忽略不中断。
+        // 每行一个帧号，可能带前后空白；空行跳过。
+        std::string line(buffer);
+        size_t      begin = line.find_first_not_of(" \t\r\n");
+        if (begin == std::string::npos)
+            continue;
+        // 合法帧号是纯数字；非数字开头的行视为 tshark 错误/警告，记首行原文供 UI 展示。
+        if (line[begin] < '0' || line[begin] > '9')
+        {
+            if (errorOut && errorOut->empty())
+            {
+                size_t e = line.find_last_not_of("\r\n");
+                *errorOut = line.substr(begin, e - begin + 1);
+            }
+            sawError = true;
+            continue;
+        }
         try
         {
-            std::string line(buffer);
-            size_t      begin = line.find_first_not_of(" \t\r\n");
-            if (begin == std::string::npos)
-                continue;
             frameNumbers.push_back(static_cast<uint32_t>(std::stoul(line.substr(begin))));
         }
         catch (const std::exception&)
@@ -377,5 +475,14 @@ bool PcapAnalyzer::getFramesByDisplayFilter(const std::string&     displayFilter
         }
     }
     ProcessUtil::PcloseEx(pipe, tsharkPid);
+
+    // 没有任何帧号且捕获到错误行：视为过滤失败（表达式非法等），返回 false 并带错误。
+    if (sawError && frameNumbers.empty())
+    {
+        if (errorOut && errorOut->empty())
+            *errorOut = "过滤表达式无效（tshark 拒绝执行）";
+        LOG_F(WARNING, "显示过滤失败（tshark 报错）: %s", displayFilter.c_str());
+        return false;
+    }
     return true;
 }

--- a/src/PcapFileReader.cpp
+++ b/src/PcapFileReader.cpp
@@ -6,9 +6,8 @@
 
 #if defined(_WIN32)
 // ============================================================================
-// 非 POSIX 兜底实现：std::ifstream + seekg/read
-// 一次打开、多次随机读，省去重复 open()/close() 并复用文件流缓冲。
-// Windows 侧暂未用原生内存映射（CreateFileMapping/MapViewOfFile），以文件流兜底。
+// 非 POSIX 兜底实现：std::ifstream + seekg/read（一次打开、多次随机读，复用文件流缓冲）。
+// Windows 暂未用原生内存映射（CreateFileMapping/MapViewOfFile）。
 // ============================================================================
 
 PcapFileReader::PcapFileReader() : size_(0) {}
@@ -54,6 +53,24 @@ bool PcapFileReader::readAt(uint64_t offset, uint32_t len, std::vector<unsigned 
     return static_cast<bool>(stream_);
 }
 
+const unsigned char* PcapFileReader::viewAt(uint64_t offset, uint32_t len) const
+{
+    if (!stream_.is_open() || offset > size_ || len > size_ - offset)
+    {
+        return nullptr;
+    }
+    // 无内存映射：读入复用缓冲再借出指针（下次调用即失效，见头注释契约）。
+    viewBuf_.resize(len);
+    stream_.clear();
+    stream_.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    stream_.read(reinterpret_cast<char*>(viewBuf_.data()), len);
+    if (!stream_)
+    {
+        return nullptr;
+    }
+    return viewBuf_.data();
+}
+
 void PcapFileReader::close()
 {
     if (stream_.is_open())
@@ -70,9 +87,8 @@ bool PcapFileReader::isOpen() const
 
 #else
 // ============================================================================
-// POSIX 实现：mmap 整个文件后按 offset 直接切片
-// 随机访问免去 lseek+read 双系统调用与一次内核→用户拷贝，
-// 页面靠缺页中断按需调入；MAP_PRIVATE + PROT_READ 只读映射，不影响原文件。
+// POSIX 实现：mmap 整个文件后按 offset 直接切片（随机访问免 lseek+read 与内核拷贝）。
+// 页面靠缺页按需调入；MAP_PRIVATE + PROT_READ 只读映射，不影响原文件。
 // ============================================================================
 
 #include <fcntl.h>
@@ -114,9 +130,8 @@ bool PcapFileReader::open(const std::string& path)
         return false;
     }
 
-    // readAt 是「按包偏移读一小段」的随机访问。内核默认按顺序访问对缺页做预读，
-    // 会把相邻页一并调入，对随机小读纯属浪费；MADV_RANDOM 关掉预读，只调入命中页。
-    // 提示失败不影响正确性（退回默认预读），故忽略返回值。
+    // readAt 是随机小读，内核默认顺序预读会白调相邻页；MADV_RANDOM 关掉预读，只调命中页。
+    // 提示失败不影响正确性（退回默认预读），忽略返回值。
     ::posix_madvise(addr, static_cast<size_t>(st.st_size), POSIX_MADV_RANDOM);
 
     fd_     = fd;
@@ -142,6 +157,16 @@ bool PcapFileReader::readAt(uint64_t offset, uint32_t len, std::vector<unsigned 
     out.resize(len);
     std::memcpy(out.data(), static_cast<const unsigned char*>(mapped_) + offset, len);
     return true;
+}
+
+const unsigned char* PcapFileReader::viewAt(uint64_t offset, uint32_t len) const
+{
+    if (mapped_ == nullptr || offset > size_ || len > size_ - offset)
+    {
+        return nullptr;
+    }
+    // 直接指向映射区：零拷贝、零分配，指针在 reader 存活期间全程有效。
+    return static_cast<const unsigned char*>(mapped_) + offset;
 }
 
 void PcapFileReader::close()

--- a/src/PdmlToJsonConverter.cpp
+++ b/src/PdmlToJsonConverter.cpp
@@ -45,8 +45,7 @@ void PdmlToJsonConverter::convertXmlNodeToJson(rapidxml::xml_node<>* xmlNode,
 
 bool PdmlToJsonConverter::convertPcapToXml(const std::string& pcapFile, const std::string& xmlFile)
 {
-    // 用 argv 方式执行 tshark，父进程读取 pdml 输出并写入 XML 文件，
-    // 避免走 shell 和 ">" 重定向，消除文件路径注入风险
+    // 用 argv 执行 tshark，父进程读 pdml 输出写入 XML 文件，避免走 shell 和 ">" 重定向的注入风险
     std::vector<std::string> args = {tsharkPath, "-r", pcapFile, "-T", "pdml"};
     ProcessUtil::ProcHandle tsharkPid = ProcessUtil::kInvalidProc;
     FILE*                    pipe      = ProcessUtil::PopenEx(args, &tsharkPid, "r");

--- a/src/gui/main_gui.cpp
+++ b/src/gui/main_gui.cpp
@@ -1,14 +1,7 @@
-// EasyTshark 原生前端
-//
-// 用 Dear ImGui（即时模式 GUI）+ GLFW/OpenGL3 后端把核心能力可视化。UI 只通过
-// AnalysisSession 门面访问数据，不直接触碰 tshark / 解析 / 数据库细节——这就是
-// 项目里的“核心库 ↔ UI 层”边界（同进程，不是网络前后端分离）。
-//
-// 布局采用 Tab 风格（顶部工具栏 + 过滤栏 + 报文/会话/统计/查询 分页 + 底部状态栏），
-// 在此之上补齐各分页的功能与显示。
-//
-// 线程约定：耗时操作（载入 pcap、停止抓包后解析入库）放到 std::async 的后台任务里跑，
-// UI 线程每帧只轮询任务是否完成，从不阻塞在解析上；完成后在 UI 线程刷新报文快照。
+// EasyTshark 原生前端（Dear ImGui + GLFW/OpenGL3）。
+// UI 只通过 AnalysisSession 门面访问数据，不直接触碰 tshark / 解析 / 数据库细节。
+// 线程约定：耗时操作（载入 pcap、停止抓包后解析入库）放到 std::async 后台任务里跑，
+// UI 线程每帧只轮询完成状态，从不阻塞在解析上。
 
 #include <algorithm>
 #include <atomic>
@@ -16,6 +9,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <deque>
+#include <fstream>
 #include <functional>
 #include <future>
 #include <map>
@@ -39,6 +34,26 @@ namespace
 {
 
 using PacketPtr = std::shared_ptr<Packet>;
+
+// 文件是否已存在（保存前用来决定是否弹「覆盖确认」）。
+bool fileExists(const std::string& path)
+{
+    if (path.empty())
+        return false;
+    std::ifstream f(path.c_str());
+    return f.good();
+}
+
+// 文件名缺扩展名时补 .pcap。只看最后一段有无 '.'，避免把目录名里的点误判为扩展名。
+std::string withPcapSuffix(const std::string& path)
+{
+    if (path.empty())
+        return path;
+    size_t slash = path.find_last_of("/\\");
+    size_t dot   = path.find_last_of('.');
+    bool   hasExt = (dot != std::string::npos) && (slash == std::string::npos || dot > slash);
+    return hasExt ? path : path + ".pcap";
+}
 
 // ---- 会话 / 统计聚合的数据结构 ----
 
@@ -89,17 +104,21 @@ struct AppState
     // 离线载入 / 保存
     char pcapPathInput[512] = {0};
     char savePathInput[512] = {0};
+    // 保存时目标文件已存在：暂存补全后的路径，弹「覆盖确认」再决定是否写入。
+    std::string pendingSaveDest;
 
     // 抓包
     std::vector<AdapterInfo> adapters;
     char                     adapterName[128] = {0};
 
-    // 实时抓包：抓包线程通过回调把包投进 liveIncoming（加锁），UI 线程每帧取出
-    // 追加到 packets，实现边抓边显示。liveCapturing 标记当前处于实时模式。
-    std::mutex             liveMutex;
-    std::vector<PacketPtr> liveIncoming;
-    bool                   liveCapturing = false;
-    bool                   autoScroll    = true;
+    // 实时抓包：抓包线程把包投进 liveIncoming（加锁），UI 线程每帧取出追加到 packets。
+    // kMaxLive 给缓冲与展示列表设上限，超限丢弃最旧包（停止后重解析得完整结果），防内存无限增长。
+    static const size_t kMaxLiveBuffered   = 20000;
+    static const size_t kMaxLiveDisplayed  = 500000;
+    std::mutex          liveMutex;
+    std::deque<PacketPtr> liveIncoming;
+    bool                  liveCapturing = false;
+    bool                  autoScroll    = true;
 
     // 会话 / 统计的缓存：仅当报文数量变化时重建，避免每帧 O(N) 聚合。
     size_t                   analyticsBuiltCount = (size_t)-1;
@@ -125,21 +144,17 @@ struct AppState
     std::string           status = "就绪";
     std::function<void()> onDone; // 任务成功后在 UI 线程执行的收尾（刷新快照等）
 
-    // 显示过滤的后台结果暂存：后台线程写 filterScratch，完成后在 UI 线程 swap 进
-    // displayFiltered，避免后台改写 displayFiltered 与 UI 绘制读它竞态。
+    // 显示过滤的后台结果暂存：后台线程写 filterScratch，完成后 UI 线程 swap 进 displayFiltered，避免竞态。
     std::vector<PacketPtr> filterScratch;
 
-    // 选中报文协议详情的后台加载：getDetailTree 要新起一个 tshark 单包 PDML 解析
-    // （约百毫秒），放后台避免每次点选卡 UI 帧。detailResult 由后台线程写、就绪后
-    // pollDetail 在 UI 线程取用。detailDraining 暂存被新点选取代、尚未完成的旧任务，
-    // 避免在点击处析构 std::async future 时阻塞 UI（其析构会 join 后台线程）。
+    // 选中报文协议详情的后台加载（getDetailTree 约百毫秒，放后台免卡帧）。
+    // detailDraining 暂存被新点选取代、尚未完成的旧任务：析构 future 会 join 阻塞 UI，故不在点击处析构。
     std::future<bool>              detailPending;
     std::shared_ptr<DetailNode>    detailResult;
     uint32_t                       detailFrame = 0;
     std::vector<std::future<bool>> detailDraining;
 
-    // tshark 可执行文件路径输入框：允许用户在 GUI 里手动指定 tshark(.exe)，无需重编译。
-    // 构造时用会话当前（已自动解析）的路径回填，方便查看/修改。
+    // tshark 路径输入框：允许在 GUI 里手动指定，无需重编译。构造时用会话当前路径回填。
     char tsharkPathInput[512] = {0};
 
     explicit AppState(AnalysisSession& s) : session(s)
@@ -207,9 +222,8 @@ ImVec4 protocolColor(const std::string& proto)
     return ImVec4(0.80f, 0.80f, 0.80f, 1.0f);
 }
 
-// 把 frame.time_epoch（自 1970 起的秒，带小数）格式化成人类可读的本地时间
-// "MM-DD HH:MM:SS.mmm"。原始时间戳信息量大但不直观，单独给一列易读时间。
-// localtime 的静态缓冲不可重入，按平台用 localtime_s / localtime_r 写入栈上 tm。
+// frame.time_epoch 格式化成本地时间 "MM-DD HH:MM:SS.mmm"。
+// localtime 静态缓冲不可重入，按平台用 localtime_s / localtime_r 写入栈上 tm。
 std::string formatEpoch(double epoch)
 {
     if (epoch <= 0.0)
@@ -276,8 +290,7 @@ void pollAsync(AppState& s)
     }
     catch (const std::exception& e)
     {
-        // 后台任务（载入 pcap、抓包、显示过滤等）内部启动 tshark 失败时会抛异常，
-        // future::get 会在 UI 线程重新抛出。这里兜住，转成失败状态，避免闪退。
+        // 后台任务抛出的异常会由 future::get 在 UI 线程重新抛出，这里兜住转成失败状态，避免闪退。
         ok       = false;
         s.busy   = false;
         s.status = std::string("失败：") + e.what();
@@ -321,12 +334,10 @@ void loadSelected(AppState& s)
     s.detailLoaded = false;
     if (!s.selectedPkt)
         return;
-    // 实时抓包途中离线分析尚未跑：随机读文件与 currentFilePath 都还没就绪，
-    // 此时取 hex/详情必然失败（且会刷 ERR 日志）。等“停止并分析”后再取。
+    // 实时抓包途中随机读文件尚未就绪，取 hex/详情必然失败，等“停止并分析”后再取。
     if (s.liveCapturing)
         return;
-    // 后台正在解析/入库时，analyzer_ 的文件与随机读取器正被改写，此刻取包会与之竞态；
-    // 等任务完成（refreshPackets 后）再取。
+    // 后台解析/入库时 analyzer_ 的文件与随机读取器正被改写，此刻取包会竞态，等任务完成后再取。
     if (s.busy)
         return;
 
@@ -335,8 +346,7 @@ void loadSelected(AppState& s)
     if (s.session.getHex(frame, s.hex))
         s.hexFrame = frame;
 
-    // 协议详情放后台：若上一次点选的任务还没跑完，先把它移进 draining 暂存，
-    // 不在点击处析构其 future（那会 join 后台线程、阻塞 UI）；pollDetail 里就绪后回收。
+    // 协议详情放后台：上次点选未完成的任务移进 draining，不在点击处析构其 future（会 join 阻塞 UI）。
     if (s.detailPending.valid())
         s.detailDraining.push_back(std::move(s.detailPending));
     s.detailResult                   = std::make_shared<DetailNode>();
@@ -396,12 +406,12 @@ void pollDetail(AppState& s)
 // 从门面刷新报文快照（在 UI 线程调用）
 void refreshPackets(AppState& s)
 {
-    s.packets     = s.session.packetsSnapshot();
+    s.packets     = *s.session.packetsSnapshot();
     s.selectedPkt = nullptr;
     s.hex.clear();
     s.detail       = DetailNode();
     s.detailLoaded = false;
-    // 可能有针对旧文件的详情任务在跑：移进 draining 等其自然结束回收，别在此析构阻塞。
+    // 针对旧文件的详情任务移进 draining 等其自然结束回收，别在此析构阻塞。
     if (s.detailPending.valid())
         s.detailDraining.push_back(std::move(s.detailPending));
     s.detailResult.reset();
@@ -417,7 +427,7 @@ void refreshPackets(AppState& s)
 // 每帧把抓包线程投递的实时包取出，追加到列表（UI 线程调用，短暂持锁只做 swap）。
 void drainLive(AppState& s)
 {
-    std::vector<PacketPtr> batch;
+    std::deque<PacketPtr> batch;
     {
         std::lock_guard<std::mutex> lk(s.liveMutex);
         if (s.liveIncoming.empty())
@@ -427,6 +437,13 @@ void drainLive(AppState& s)
     for (const PacketPtr& p : batch)
         s.totalBytes += p->len;
     s.packets.insert(s.packets.end(), batch.begin(), batch.end());
+    // 实时展示列表上限：超限丢弃最旧的一半（保留最新报文），并提示完整结果可在停止后查看。
+    if (s.packets.size() > AppState::kMaxLiveDisplayed)
+    {
+        size_t drop = s.packets.size() - AppState::kMaxLiveDisplayed;
+        s.packets.erase(s.packets.begin(), s.packets.begin() + drop);
+        s.status = "实时列表超上限，已丢弃最早报文（停止后可查看完整结果）";
+    }
     s.viewDirty = true;
 }
 
@@ -573,19 +590,51 @@ void drawToolbar(AppState& s)
     ImGui::TextUnformatted("  |  保存:");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(240);
-    ImGui::InputTextWithHint("##savepath", "另存为 .pcap 路径", s.savePathInput,
+    ImGui::InputTextWithHint("##savepath", "另存为 .pcap 路径（缺目录会自动创建）", s.savePathInput,
                              sizeof(s.savePathInput));
     ImGui::SameLine();
     ImGui::BeginDisabled(s.busy || s.session.pcapPath().empty());
     if (ImGui::Button("保存"))
     {
-        std::string dest = s.savePathInput;
-        s.status = s.session.savePcapAs(dest) ? ("已保存: " + dest) : "保存失败";
+        std::string dest = withPcapSuffix(s.savePathInput); // 缺后缀补 .pcap
+        if (dest.empty())
+        {
+            s.status = "请先填写保存路径";
+        }
+        else if (fileExists(dest) && dest != s.session.pcapPath())
+        {
+            // 目标已存在（且不是当前源文件本身）：先弹确认，避免误覆盖。
+            s.pendingSaveDest = dest;
+            ImGui::OpenPopup("确认覆盖");
+        }
+        else
+        {
+            s.status = s.session.savePcapAs(dest) ? ("已保存: " + dest) : "保存失败";
+        }
     }
     ImGui::EndDisabled();
 
-    // tshark 路径：显示当前解析到的路径，允许手动改指到 tshark(.exe) 后应用（无需重编译）。
-    // 未检测到时红字提示并给出下载地址，引导用户安装 Wireshark。
+    // 覆盖确认弹窗：目标文件已存在时由「保存」按钮触发。
+    if (ImGui::BeginPopupModal("确认覆盖", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::Text("文件已存在：\n%s\n\n确定覆盖？", s.pendingSaveDest.c_str());
+        ImGui::Separator();
+        if (ImGui::Button("覆盖"))
+        {
+            s.status = s.session.savePcapAs(s.pendingSaveDest) ? ("已保存: " + s.pendingSaveDest)
+                                                               : "保存失败";
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("取消"))
+        {
+            s.status = "已取消保存";
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    // tshark 路径：显示当前路径，允许手动改指后应用；未检测到时红字提示并给出下载地址。
     ImGui::TextUnformatted("tshark 路径:");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(360);
@@ -615,8 +664,7 @@ void drawToolbar(AppState& s)
     ImGui::SameLine();
     if (ImGui::Button("刷新网卡"))
     {
-        // 枚举网卡会启动 tshark 子进程；若 tshark 未安装/不在默认路径，listAdapters 会抛
-        // std::runtime_error。这里必须捕获——否则异常冲出 ImGui 帧循环导致整个窗口闪退。
+        // listAdapters 会启动 tshark，失败时抛异常；必须捕获，否则异常冲出 ImGui 帧循环致窗口闪退。
         try
         {
             s.adapters = s.session.listAdapters();
@@ -668,6 +716,8 @@ void drawToolbar(AppState& s)
             {
                 std::lock_guard<std::mutex> lk(sp->liveMutex);
                 sp->liveIncoming.push_back(p);
+                if (sp->liveIncoming.size() > AppState::kMaxLiveBuffered)
+                    sp->liveIncoming.pop_front(); // 抓包线程丢弃最旧，O(1)
             });
         if (ok)
         {
@@ -703,8 +753,7 @@ void drawFilterBar(AppState& s)
     bool find = ImGui::Button("查找");
     if ((find || enter) && s.filterExpr[0])
     {
-        // 显示过滤要跑一次 tshark（-Y），放后台，避免在 UI 线程同步等待卡帧。
-        // 后台写 filterScratch，成功后在 onDone（UI 线程）swap 进 displayFiltered。
+        // 显示过滤要跑一次 tshark（-Y），放后台免卡帧；成功后在 onDone 里 swap 进 displayFiltered。
         std::string expr = s.filterExpr;
         AppState*   sp   = &s;
         beginAsync(s,
@@ -822,9 +871,8 @@ void drawPacketTable(AppState& s)
         ImGui::Text("共 %zu 条%s", s.view.size(), s.displayFilterOn ? "（已过滤）" : "");
     }
 
-    // ScrollX：窗口偏窄时列会被挤压到显示不全（IP/归属地被截成“...”）。开启横向滚动后
-    // 各列保持固定宽度、总宽超出可视区时可左右拖动查看完整内容。
-    // 注意：ScrollX 下 WidthStretch 列不再自动填充，故下面把原先拉伸的列改为固定宽度。
+    // ScrollX：窗口偏窄时开启横向滚动，各列保持固定宽度可左右拖动。
+    // 注意：ScrollX 下 WidthStretch 列不再自动填充，故下面各列改为固定宽度。
     const ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                   ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollX |
                                   ImGuiTableFlags_Resizable;
@@ -940,8 +988,7 @@ void drawDetail(AppState& s)
 
     // 协议分层树（占上半区）
     ImGui::TextUnformatted("协议分层:");
-    // 加 HorizontalScrollbar：深层嵌套字段展开后单行常超出可视宽度，
-    // 无横向滚动只能被裁剪；有了它可左右拖动查看完整内容。
+    // 加 HorizontalScrollbar：深层嵌套字段展开后单行常超出可视宽度，可左右拖动查看。
     ImGui::BeginChild("prototree", ImVec2(0, ImGui::GetContentRegionAvail().y * 0.5f), true,
                       ImGuiWindowFlags_HorizontalScrollbar);
     if (s.detailLoaded && !s.detail.children.empty())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <string>
 #include <thread>
@@ -14,8 +15,7 @@
 #include <windows.h> // SetConsoleOutputCP / SetConsoleCP
 #endif
 
-// main 只负责命令行交互与装配：读取用户输入、调用 AnalysisSession 门面，
-// 所有抓包 / 解析 / 入库 / 查询逻辑都在门面内部，UI（此处是 CLI）不碰实现细节。
+// main 只负责命令行交互与装配：读用户输入、调用 AnalysisSession 门面，不碰实现细节。
 
 namespace
 {
@@ -88,11 +88,13 @@ void runQueryLoop(AnalysisSession& session)
 int main(int argc, char* argv[])
 {
 #if defined(_WIN32)
-    // 源码里的中文提示均为 UTF-8 字节；Windows 控制台默认按本地代码页(GBK/936)解码，
-    // 会把 UTF-8 中文显示成乱码。把控制台输入/输出代码页都切到 UTF-8 即可正常显示。
+    // Windows 控制台默认按本地代码页(GBK)解码会把 UTF-8 中文显示成乱码，切到 UTF-8 修正。
     SetConsoleOutputCP(CP_UTF8);
     SetConsoleCP(CP_UTF8);
 #endif
+
+    // logs/ 只保留最近 10 个日志文件，防止无限累积。
+    CommonUtil::pruneLogFiles("logs", 10);
 
     std::string ts               = CommonUtil::get_timestamp();
     std::string capture_log_name = "logs/capture_" + ts + ".log";
@@ -103,24 +105,34 @@ int main(int argc, char* argv[])
     std::string     tsharkPath = TsharkCommand::resolveTsharkPath();
     AnalysisSession session(tsharkPath, "data");
 
-    // 未检测到 tshark 时给出友好引导（本工具依赖 Wireshark 的 tshark 做抓包/解析）。
-    // 这里只提示不退出：仍进入菜单，真正用到 tshark 的操作会各自报错。
+    // 未检测到 tshark 时告知降级到内置解析引擎，安装 Wireshark 可获得完整协议支持。
     if (!TsharkCommand::tsharkAvailable(tsharkPath))
     {
-        std::cerr << "警告：未检测到 tshark（已尝试路径: " << tsharkPath << "）。\n"
-                  << "本工具依赖 Wireshark 提供的 tshark。请先安装 Wireshark："
+        std::cerr << "提示：未检测到 tshark（已尝试路径: " << tsharkPath << "），"
+                  << "将使用内置解析引擎（覆盖常用协议）。\n"
+                  << "安装 Wireshark 可解锁完整协议详情："
                   << TsharkCommand::wiresharkDownloadUrl() << "\n"
-                  << "若已安装在非默认位置，可设置环境变量 EASYTSHARK_TSHARK 指向 tshark"
-#if defined(_WIN32)
-                     ".exe"
-#endif
-                  << " 的完整路径。\n"
+                  << "也可设置环境变量 EASYTSHARK_TSHARK 指定 tshark 路径。\n"
                   << std::endl;
     }
 
     int mode = 0;
-    std::cout << "请选择模式：\n1. 实时抓包\n2. 离线分析\n请输入选择 (1或2): ";
-    std::cin >> mode;
+    // 输入校验：非数字 / 非法选项时循环重试（避免 cin 失败流死循环与误退出）
+    while (true)
+    {
+        std::cout << "请选择模式：\n1. 实时抓包\n2. 离线分析\n请输入选择 (1或2): ";
+        std::cin >> mode;
+        if (std::cin.fail())
+        {
+            std::cin.clear();
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            std::cout << "输入无效，请输入数字 1 或 2。" << std::endl;
+            continue;
+        }
+        if (mode == 1 || mode == 2)
+            break;
+        std::cout << "无效的选择，请输入 1 或 2。" << std::endl;
+    }
 
     if (mode == 1)
     {
@@ -149,16 +161,32 @@ int main(int argc, char* argv[])
         std::cin >> adapterName;
 
         int captureSeconds = 0;
-        std::cout << "请输入抓包时间(秒): ";
-        std::cin >> captureSeconds;
+        // 抓包时长：1~86400 秒（1 天）内合法；非数字 / 越界时循环重试
+        while (true)
+        {
+            std::cout << "请输入抓包时间(秒，1~86400): ";
+            std::cin >> captureSeconds;
+            if (std::cin.fail())
+            {
+                std::cin.clear();
+                std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                std::cout << "输入无效，请输入数字。" << std::endl;
+                continue;
+            }
+            if (captureSeconds >= 1 && captureSeconds <= 86400)
+                break;
+            std::cout << "时长需在 1~86400 秒之间。" << std::endl;
+        }
 
         std::cout << "开始抓包，持续 " << captureSeconds << " 秒..." << std::endl;
-        if (!session.startLiveCapture(adapterName))
+        // -a duration:N 让 tshark 到点自行收尾，轮询等其结束，stopLiveCapture 只负责解析入库。
+        if (!session.startLiveCapture(adapterName, nullptr, captureSeconds))
         {
             std::cerr << "启动抓包失败" << std::endl;
             return 1;
         }
-        std::this_thread::sleep_for(std::chrono::seconds(captureSeconds));
+        while (session.isCapturing())
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
         if (!session.stopLiveCapture())
         {

--- a/src/platform/EventPollerPoll.cpp
+++ b/src/platform/EventPollerPoll.cpp
@@ -1,9 +1,6 @@
 // EventPoller 的 poll() 实现：Linux 与 macOS 共用。
-//
-// poll() 是 POSIX 标准，在所有类 Unix 系统上可用，且支持管道 fd，
-// 因此一份代码即可覆盖 Linux + macOS，无需为 mac 单独写 kqueue。
-// Windows 无法用它多路复用匿名管道（WSAPoll 仅限 socket），
-// 由 src/platform/EventPollerWin.cpp 实现同一套接口。
+// poll() 是 POSIX 标准且支持管道 fd，一份代码覆盖 Linux+macOS，无需为 mac 写 kqueue。
+// Windows 无法用它多路复用匿名管道，由 src/platform/EventPollerWin.cpp 实现同一接口。
 
 #include "platform/EventPoller.hpp"
 

--- a/src/platform/EventPollerWin.cpp
+++ b/src/platform/EventPollerWin.cpp
@@ -1,13 +1,7 @@
 // EventPoller 的 Windows 实现。
-//
-// 为什么不用 poll/WSAPoll：Windows 的 WSAPoll 只支持套接字，而本项目多路复用的是
-// tshark 子进程的匿名管道（CreatePipe），套接字 API 对其无效。故这里用轮询式探测：
-// 对每个已注册 fd，用 _get_osfhandle 取回底层管道 HANDLE，再用 PeekNamedPipe 查看
-// 是否有可读数据或对端是否关闭。语义与 poll 版一致：返回“本次可读/对端关闭/出错”的 fd 列表。
-//
-// 精度取舍：PeekNamedPipe 无法像 poll 那样阻塞等待，故 wait() 采用“小步睡眠 + 轮询”
-// 逼近 timeoutMs。tshark 流量统计是低频秒级数据，这点延迟可接受；且 FlowMonitor 本就
-// 以 500ms 为轮询周期。接口、线程安全语义与 EventPollerPoll.cpp 保持完全一致。
+// 为什么不用 WSAPoll：它只支持套接字，而这里多路复用的是 tshark 子进程的匿名管道。
+// 故改用轮询式探测：对每个 fd 用 PeekNamedPipe 查可读数据/对端关闭，语义与 poll 版一致。
+// 取舍：PeekNamedPipe 不能阻塞，wait() 用“小步睡眠 + 轮询”逼近 timeoutMs（低频数据可接受）。
 
 #include "platform/EventPoller.hpp"
 

--- a/src/platform/PipeIOWin.cpp
+++ b/src/platform/PipeIOWin.cpp
@@ -1,7 +1,5 @@
-// PipeIO 的 Windows 实现。
-// Windows 匿名管道不支持 fd 级非阻塞，故用 PeekNamedPipe 先探测可读字节数，
-// 只在确有数据时 ReadFile 相应数量，从而不阻塞。fd 是 _open_osfhandle 封装出的
-// CRT 描述符，用 _get_osfhandle 取回底层管道 HANDLE。
+// PipeIO 的 Windows 实现：匿名管道不支持 fd 级非阻塞，故先 PeekNamedPipe 探测可读量，
+// 有数据才 ReadFile，从而不阻塞。fd 是 CRT 描述符，用 _get_osfhandle 取回管道 HANDLE。
 
 #include "platform/PipeIO.hpp"
 

--- a/src/processUtil.cpp
+++ b/src/processUtil.cpp
@@ -3,16 +3,8 @@
 #if defined(_WIN32)
 // ============================================================================
 // Windows 实现：CreateProcess + 匿名管道（CreatePipe）
-//
-// 与 POSIX 的 fork+execvp 对应关系：
-//   fork+execvp        → CreateProcessA（一步创建并加载新程序，无 fork 语义）
-//   pipe()             → CreatePipe（匿名管道，用于父子间重定向 stdout/stdin）
-//   dup2 到 STDOUT     → STARTUPINFO.hStdOutput/hStdInput + STARTF_USESTDHANDLES
-//   waitpid            → WaitForSingleObject + GetExitCodeProcess
-//   kill(SIGTERM)      → TerminateProcess（注意：等价 SIGKILL，非优雅收尾，见下）
-//
-// 句柄继承：管道给子进程用的那一端必须可继承（SECURITY_ATTRIBUTES.bInheritHandle），
-// 父进程自留的那一端用 SetHandleInformation 去掉继承标志，否则子进程退出后父端收不到 EOF。
+// 句柄继承：给子进程的管道端须可继承，父进程自留端用 SetHandleInformation 去掉继承标志，
+// 否则子进程退出后父端收不到 EOF。TerminateProcess 等价 SIGKILL，非优雅收尾。
 // ============================================================================
 
 #include <cstdint>
@@ -23,8 +15,7 @@
 
 namespace
 {
-// 按 Windows CommandLineToArgvW 的规则对单个参数加引号转义：
-// 仅在含空白或引号时加外层双引号；反斜杠只有在紧邻引号时才需成对转义。
+// 按 CommandLineToArgvW 规则给参数加引号转义：含空白/引号才加外层引号，反斜杠仅紧邻引号时成对转义。
 std::string quoteArg(const std::string& arg)
 {
     if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos)
@@ -77,9 +68,9 @@ std::string argvToCommandLine(const std::vector<std::string>& argv)
     return cmd;
 }
 
-// 创建子进程并把其 stdout（读模式）或 stdin（写模式）接到匿名管道，
-// 父端封装成 FILE* 返回。pidOut 收子进程 HANDLE，供后续等待/终止。
-FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut, bool readMode)
+// 创建子进程并把其 stdout(读)/stdin(写) 接到匿名管道，父端封装成 FILE* 返回；pidOut 收子进程 HANDLE。
+FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut, bool readMode,
+                          bool mergeStderr)
 {
     SECURITY_ATTRIBUTES sa;
     sa.nLength              = sizeof(sa);
@@ -104,7 +95,8 @@ FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut,
     if (readMode)
     {
         si.hStdOutput = childEnd; // 子进程 stdout → 管道写端
-        si.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+        // mergeStderr：stderr 一并写入管道（如 tshark 的 -Y 错误信息），否则透传父进程
+        si.hStdError  = mergeStderr ? childEnd : GetStdHandle(STD_ERROR_HANDLE);
         si.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
     }
     else
@@ -121,10 +113,8 @@ FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut,
     std::vector<char> mutableCmd(cmdline.begin(), cmdline.end());
     mutableCmd.push_back('\0');
 
-    // CREATE_NEW_PROCESS_GROUP：让子进程自成进程组，为将来用 GenerateConsoleCtrlEvent
-    // 做优雅停止预留可能（当前 Kill 仍用 TerminateProcess）。
-    // CREATE_NO_WINDOW：父进程是 GUI 时，控制台程序 tshark 会弹出黑色控制台窗口；
-    // 加此标志令其不创建控制台。我们只经匿名管道读它的 stdout，功能不受影响。
+    // CREATE_NEW_PROCESS_GROUP：为将来 GenerateConsoleCtrlEvent 优雅停止预留。
+    // CREATE_NO_WINDOW：GUI 父进程下不为控制台程序 tshark 弹出黑框（只经管道读 stdout，不受影响）。
     BOOL ok = CreateProcessA(nullptr, mutableCmd.data(), nullptr, nullptr,
                              TRUE, // 继承句柄（含上面可继承的 childEnd）
                              CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW, nullptr, nullptr, &si,
@@ -143,8 +133,7 @@ FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut,
     if (pidOut)
         *pidOut = pi.hProcess; // 交出进程 HANDLE（由 PcloseEx/Kill 负责 CloseHandle）
 
-    // 把父端 HANDLE 交给 CRT：_open_osfhandle 成功后该 HANDLE 归 fd 所有，
-    // 关闭 FILE*/fd 即关闭底层管道句柄，不可再单独 CloseHandle(parentEnd)。
+    // 父端 HANDLE 交给 CRT：_open_osfhandle 成功后归 fd 所有，关闭 fd 即关句柄，不可再 CloseHandle。
     int osFlags = readMode ? _O_RDONLY : _O_WRONLY;
     int fd      = _open_osfhandle(reinterpret_cast<intptr_t>(parentEnd), osFlags);
     if (fd == -1)
@@ -217,11 +206,12 @@ FILE* ProcessUtil::PopenEx(const char* command, ProcHandle* pid, const char* typ
     return spawnWithPipe(shellCmd, pid, type[0] == 'r');
 }
 
-FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid, const char* type)
+FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid,
+                            const char* type, bool mergeStderr)
 {
     if (argv.empty())
         return nullptr;
-    return spawnWithPipe(argvToCommandLine(argv), pid, type[0] == 'r');
+    return spawnWithPipe(argvToCommandLine(argv), pid, type[0] == 'r', mergeStderr);
 }
 
 bool ProcessUtil::Kill(ProcHandle pid)
@@ -231,8 +221,7 @@ bool ProcessUtil::Kill(ProcHandle pid)
 
     HANDLE hProc = static_cast<HANDLE>(pid);
     // 注意：TerminateProcess 等价 SIGKILL，tshark 不会 flush -w 文件即被杀。
-    // 若将来需要“优雅收尾”，可对 CREATE_NEW_PROCESS_GROUP 的子进程发
-    // GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, dwProcessId)，此处从简。
+    // 若需优雅收尾可对进程组发 GenerateConsoleCtrlEvent，此处从简。
     BOOL terminated = TerminateProcess(hProc, 1);
     WaitForSingleObject(hProc, INFINITE); // 回收，避免句柄悬挂
     CloseHandle(hProc);
@@ -243,8 +232,7 @@ bool ProcessUtil::Signal(ProcHandle pid)
 {
     if (!ValidProc(pid))
         return false;
-    // 只请求终止，不 WaitForSingleObject / 不 CloseHandle：回收留给配套的 PcloseEx。
-    // 同 Kill 的局限：TerminateProcess 无法让 tshark flush -w 文件（Windows 无 SIGTERM 语义）。
+    // 只请求终止，回收留给配套的 PcloseEx；同 Kill：无法让 tshark flush -w 文件。
     return TerminateProcess(static_cast<HANDLE>(pid), 1) != FALSE;
 }
 
@@ -294,9 +282,8 @@ bool ProcessUtil::Exec(const std::vector<std::string>& argv)
     if (argv.empty())
         return false;
 
-    // 在 fork 之前构建 argv 数组：多线程程序里 fork 之后、exec 之前只能调用
-    // async-signal-safe 函数，若此刻别的线程正持有 malloc 锁，子进程再分配就会死锁。
-    // cargv 里的指针指向 argv 各字符串的缓冲，父进程持续存活、子进程经 COW 共享，均有效。
+    // fork 前构建 argv：fork 后 exec 前只能调 async-signal-safe 函数，此刻别的线程持 malloc 锁会死锁。
+    // cargv 指针指向 argv 缓冲，父进程存活、子进程 COW 共享，均有效。
     std::vector<char*> cargv;
     cargv.reserve(argv.size() + 1);
     for (const auto& arg : argv)
@@ -320,11 +307,8 @@ bool ProcessUtil::Exec(const std::vector<std::string>& argv)
     return WIFEXITED(status) && WEXITSTATUS(status) == 0;
 }
 
-// @warning 该 const char* 版经由 /bin/sh -c 执行命令，存在两点代价：
-//   1) 多派生一层 shell 进程（fork+exec(sh)，sh 再 fork+exec 目标程序）；
-//   2) 命令中的 ; | $() ` 等元字符会被 shell 解释，拼接用户输入会造成注入。
-// 因此仅供测试等可信、固定命令场景使用。业务热路径（抓包/解析/监控）一律用下方
-// 接收 argv 向量的重载，走 execvp 直接替换地址空间，既省一层进程也无注入面。
+// @warning 该 const char* 版经 /bin/sh -c 执行：多一层 shell 进程，且 ; | $() ` 等元字符会被
+// shell 解释，拼接用户输入会注入。仅供测试等可信、固定命令场景；业务热路径一律用下方 argv 重载。
 FILE* ProcessUtil::PopenEx(const char* command, ProcHandle* pid, const char* type)
 {
     int   pipefd[2];
@@ -375,7 +359,8 @@ FILE* ProcessUtil::PopenEx(const char* command, ProcHandle* pid, const char* typ
     }
 }
 
-FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid, const char* type)
+FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid,
+                            const char* type, bool mergeStderr)
 {
     if (argv.empty())
         return nullptr;
@@ -391,10 +376,9 @@ FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid
     if (pipe(pipefd) < 0)
         return nullptr;
 
-    // 两端立即置 FD_CLOEXEC：多线程下同时有多个网卡管道时，若不设置，后 fork 的子进程
-    // 会继承前面管道的描述符，导致前一个管道在其对应 tshark 退出后仍收不到 EOF。子进程
-    // dup2 到 stdio 的那一端由 dup2 清除 CLOEXEC 而在 exec 后存活，原始描述符则于 exec 时
-    // 自动关闭。pipe()→fcntl 之间仍有极窄竞态窗口（macOS 无 pipe2 无法原子设置），可接受。
+    // 两端立即置 FD_CLOEXEC：多网卡管道并发时若不设，后 fork 的子进程会继承前面管道的 fd，
+    // 导致前一个管道在其 tshark 退出后收不到 EOF。dup2 到 stdio 的端会清除 CLOEXEC 而存活。
+    // pipe()→fcntl 间有极窄竞态（macOS 无 pipe2 无法原子设置），可接受。
     fcntl(pipefd[0], F_SETFD, FD_CLOEXEC);
     fcntl(pipefd[1], F_SETFD, FD_CLOEXEC);
 
@@ -412,6 +396,8 @@ FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid
         {
             close(pipefd[0]);
             dup2(pipefd[1], STDOUT_FILENO);
+            if (mergeStderr)
+                dup2(pipefd[1], STDERR_FILENO); // stderr 合并进管道（错误信息可读）
         }
         else
         {
@@ -445,8 +431,7 @@ bool ProcessUtil::Kill(ProcHandle pid)
     if (pid <= 0)
         return false;
 
-    // 即便进程可能已自行退出（kill 返回 -1，如 EOF 后的僵尸），仍要 waitpid 回收其残留，
-    // 否则会漏掉一个僵尸进程。故不因 kill 失败提前返回。
+    // 即便进程已自行退出（kill 返回 -1），仍要 waitpid 回收残留避免僵尸，故不因 kill 失败提前返回。
     bool signaled = (kill(pid, SIGTERM) == 0);
 
     int  status;

--- a/src/tsharkCommand.cpp
+++ b/src/tsharkCommand.cpp
@@ -17,8 +17,7 @@ namespace TsharkCommand
 
 namespace
 {
-// 判断给定路径是否为可打开的现有文件。tshark/editcap 都是普通可执行文件，
-// 用 fopen("rb") 做存在性探测：跨平台、无额外依赖，能打开即存在且可读。
+// 判断路径是否为可打开的现有文件（fopen 探测：跨平台、无额外依赖）。
 bool fileReadable(const std::string& path)
 {
     if (path.empty())
@@ -66,8 +65,7 @@ std::string searchInPath(const std::string& exeName)
 }
 
 #if defined(_WIN32)
-// 从注册表读 Wireshark 安装目录：安装程序会写 HKLM\SOFTWARE\Wireshark 的 InstallDir，
-// 64 位机上也可能落在 WOW6432Node。读到目录后拼上 tshark.exe，存在才返回。仅 Windows 编译。
+// 从注册表 HKLM\SOFTWARE\Wireshark（含 WOW6432Node）读 InstallDir，拼 tshark.exe。仅 Windows。
 std::string tsharkFromRegistry()
 {
     const char* subKeys[] = {"SOFTWARE\\Wireshark", "SOFTWARE\\WOW6432Node\\Wireshark"};
@@ -222,13 +220,8 @@ bool tsharkAvailable(const std::string& path)
 
 std::string resolveTsharkPath()
 {
-    // 解析顺序（先命中先用）：
-    //   1. 环境变量 EASYTSHARK_TSHARK：用户显式覆盖，最高优先级，无需重编译。
-    //   2. 平台默认路径：多数标准安装命中于此。
-    //   3. PATH：tshark 在环境变量里可直接找到（Linux/macOS 常见）。
-    //   4. Windows 注册表 Wireshark InstallDir（含 WOW6432Node）。
-    //   5. 常见安装目录兜底。
-    // 全都没命中时回退平台默认路径，让后续报错信息仍指向一个合理位置。
+    // 解析顺序（先命中先用）：环境变量 EASYTSHARK_TSHARK（用户覆盖）→ 平台默认路径 →
+    // PATH → Windows 注册表 InstallDir → 常见安装目录。全不命中则回退平台默认路径。
     if (const char* env = std::getenv("EASYTSHARK_TSHARK"))
     {
         if (env[0] != 0 && fileReadable(env))
@@ -260,8 +253,7 @@ std::string resolveTsharkPath()
 
 std::string resolveEditcapPath()
 {
-    // editcap 与 tshark 同目录发行：直接从解析到的 tshark 路径推导，保证两者版本/位置一致。
-    // 推导不出或该文件不存在时回退平台默认 editcap 路径。
+    // editcap 与 tshark 同目录发行：从解析到的 tshark 路径推导；推导不出则回退默认。
     std::string tshark = resolveTsharkPath();
     std::size_t slash  = tshark.find_last_of("/\\");
     if (slash != std::string::npos)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -11,6 +11,16 @@
 #include <unordered_map>
 #include <vector>
 
+#if defined(_WIN32)
+#include <direct.h> // _findfirst/_findnext 用到的头在 <io.h>
+#include <io.h>
+#include <sys/stat.h>
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
+
 #include "loguru/loguru.hpp"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
@@ -38,7 +48,6 @@ std::unordered_map<std::string, std::string> translationMap = {
     {"Time delta from previous captured frame", "与上一个捕获帧的时间差"},
     {"Time delta from previous displayed frame", "与上一个显示帧的时间差"},
     {"Time since reference or first frame", "自参考帧或第一帧以来的时间"},
-    {"Frame Number", "帧编号"},
     {"Frame Length", "帧长度"},
     {"Capture Length", "捕获长度"},
     {"Frame is marked", "帧标记"},
@@ -122,8 +131,7 @@ std::string IP2RegionUtil::getIpLocation(const std::string& ip)
         return "";
     }
 
-    // 记忆化：少数 IP 贡献绝大多数报文，命中缓存即跳过 xdb 查表与 parseLocation 分配。
-    // 离线分析与抓包线程可能并发调用，用静态 mutex 守护。
+    // 记忆化：少数 IP 贡献绝大多数报文；离线与抓包线程并发调用，用静态 mutex 守护。
     static std::unordered_map<std::string, std::string> locationCache;
     static std::mutex                                    cacheMutex;
     {
@@ -157,8 +165,7 @@ std::string IP2RegionUtil::parseLocation(const std::string& input)
         return "内网";
     }
 
-    // 按 '|' 切分为「国家|区域|省份|城市|ISP」5 段。手动扫描按需 substr，
-    // 免去 stringstream + getline 每次构造流对象的开销。
+    // 按 '|' 切分为「国家|区域|省份|城市|ISP」5 段（手动扫描避免 stringstream 开销）。
     std::string tokens[5];
     int         count = 0;
     size_t      start = 0;
@@ -200,9 +207,8 @@ std::string IP2RegionUtil::parseLocation(const std::string& input)
 
 bool IP2RegionUtil::init(const std::string& xdbFilePath)
 {
-    // 只初始化一次：xdb 文件较大，离线分析与抓包线程都会调用 init。call_once
-    // 保证仅加载一次，并对所有调用线程建立 happens-before，之后读 xdbPtr 皆安全。
-    // 加载失败置空并返回 false，不让异常沿离线分析路径冒泡到 UI 线程。
+    // call_once 保证 xdb 只加载一次并对所有调用线程建立 happens-before；
+    // 加载失败置空返回 false，不让异常冒泡到 UI 线程。
     static std::once_flag initFlag;
     std::call_once(initFlag,
                    [&xdbFilePath]()
@@ -211,6 +217,11 @@ bool IP2RegionUtil::init(const std::string& xdbFilePath)
                        {
                            std::shared_ptr<xdb_search_t> p =
                                std::make_shared<xdb_search_t>(xdbFilePath);
+                           if (!p->is_ok())
+                           {
+                               xdbPtr = nullptr; // 库文件缺失：降级为空归属地
+                               return;
+                           }
                            p->init_content();
                            xdbPtr = p;
                        }
@@ -228,8 +239,7 @@ std::string CommonUtil::get_timestamp()
     auto now_time = std::chrono::system_clock::to_time_t(now);
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
 
-    // std::localtime 返回指向共享静态缓冲区的指针，并发调用会相互覆盖（数据竞争）。
-    // 改用可重入版本写入线程内的 tm：POSIX 用 localtime_r，Windows 用 localtime_s。
+    // localtime 用共享静态缓冲，并发有数据竞争；改用可重入版写线程内 tm。
     std::tm tm_buf{};
 #if defined(_WIN32)
     localtime_s(&tm_buf, &now_time);
@@ -243,13 +253,69 @@ std::string CommonUtil::get_timestamp()
 
     return ss.str();
 }
+void CommonUtil::pruneLogFiles(const std::string& dir, size_t keep)
+{
+#if defined(_WIN32)
+    // Windows 下用 _findfirst/_findnext 枚举 *.log；按文件名时间戳排序后删除最旧的。
+    std::vector<std::string> files;
+    std::string              pattern = dir + "\\*.log";
+    struct _finddata_t       fd;
+    intptr_t                 h = _findfirst(pattern.c_str(), &fd);
+    if (h == -1)
+        return; // 目录不存在 / 无匹配
+    do
+    {
+        if (fd.name[0] != '.')
+            files.push_back(dir + "\\" + fd.name);
+    } while (_findnext(h, &fd) == 0);
+    _findclose(h);
+#else
+    std::vector<std::string> files;
+    DIR*                     d = opendir(dir.c_str());
+    if (!d)
+        return;
+    struct dirent* ent;
+    while ((ent = readdir(d)) != nullptr)
+    {
+        std::string name = ent->d_name;
+        // 只匹配 .log 后缀（日志文件命名规则）
+        if (name.size() > 4 && name.compare(name.size() - 4, 4, ".log") == 0)
+            files.push_back(dir + "/" + name);
+    }
+    closedir(d);
+#endif
+    if (files.size() <= keep)
+        return;
+
+    // 按最后修改时间升序（最旧在前），删除超出的最旧文件
+    std::sort(files.begin(), files.end(),
+              [](const std::string& a, const std::string& b)
+              {
+#if defined(_WIN32)
+                  struct _stat stA, stB;
+                  if (_stat(a.c_str(), &stA) != 0)
+                      return false;
+                  if (_stat(b.c_str(), &stB) != 0)
+                      return true;
+                  return stA.st_mtime < stB.st_mtime;
+#else
+                  struct stat stA, stB;
+                  if (stat(a.c_str(), &stA) != 0)
+                      return false;
+                  if (stat(b.c_str(), &stB) != 0)
+                      return true;
+                  return stA.st_mtime < stB.st_mtime;
+#endif
+              });
+    for (size_t i = 0; i < files.size() - keep; ++i)
+        std::remove(files[i].c_str());
+}
+
 
 
 namespace
 {
-// 前缀树（trie）：在 O(待匹配串长) 内找出 showname 的最长匹配前缀。
-// 取代原先对约 80 条词典逐条 find(key)==0 的 O(串长×词典大小) 扫描，
-// 且总是选中最长（最具体）的前缀，结果确定。
+// 前缀树：O(串长) 找出 showname 的最长匹配前缀，取代对词典逐条 find 的扫描，且总选最长前缀。
 class TranslationTrie
 {
 public:
@@ -379,12 +445,9 @@ SQLiteUtil::SQLiteUtil(const std::string& dbname)
         throw std::runtime_error("Failed to open database");
     }
 
-    // 该库是可从 pcap 随时重建的「派生缓存」，无需为掉电持久化付出每次 COMMIT
-    // 都 fsync 的代价（fsync 会让入库流水线卡在磁盘 I/O 上）：
-    //   - journal_mode=MEMORY：回滚日志放内存，省去日志文件创建与 fsync；
-    //   - synchronous=OFF：COMMIT 不再 fsync（掉电可能损坏，但源头 pcap 仍在，可重建）；
-    //   - temp_store=MEMORY：临时表/索引走内存。
-    // PRAGMA 失败只会退回更慢但同样正确的默认行为，故不因此中断构造。
+    // 该库可从 pcap 随时重建（派生缓存），故牺牲持久化换性能：journal_mode=MEMORY /
+    // synchronous=OFF（COMMIT 不 fsync）/ temp_store=MEMORY。掉电可能损坏，但源头 pcap 仍在。
+    // PRAGMA 失败会退回更慢但同样正确的默认，不因此中断构造。
     sqlite3_exec(db, "PRAGMA journal_mode = MEMORY;", nullptr, nullptr, nullptr);
     sqlite3_exec(db, "PRAGMA synchronous = OFF;", nullptr, nullptr, nullptr);
     sqlite3_exec(db, "PRAGMA temp_store = MEMORY;", nullptr, nullptr, nullptr);
@@ -452,14 +515,15 @@ bool SQLiteUtil::insertPacket(std::vector<std::shared_ptr<Packet>>& packets)
     if (sqlite3_prepare_v2(db, insertSQL.c_str(), -1, &stmt, nullptr) != SQLITE_OK)
     {
         LOG_F(ERROR, "Failed to prepare insert statement: %s", sqlite3_errmsg(db));
+        // 上面已 BEGIN，此处失败必须回滚，否则事务悬挂在连接上直至对象销毁。
+        sqlite3_exec(db, "ROLLBACK;", nullptr, nullptr, nullptr);
         return false;
     }
 
     bool hasError = false;
     for (const auto& packet : packets)
     {
-        // 文本列传入显式长度（.size()）而非 -1：-1 会让 SQLite 对每串各做一次
-        // strlen，批量 N 包 × 8 列即 8N 次全串扫描。SQLITE_STATIC 表示不拷贝，
+        // 文本列传显式长度而非 -1，省去 SQLite 对每串的 strlen；SQLITE_STATIC 不拷贝，
         // 字符串由 packet 在本次事务结束前持有。
         sqlite3_bind_int(stmt, 1, packet->frame_number);
         sqlite3_bind_double(stmt, 2, packet->time);
@@ -516,16 +580,14 @@ bool SQLiteUtil::insertPacket(std::vector<std::shared_ptr<Packet>>& packets)
 
 namespace
 {
-// sqlite3_column_text 对 NULL 列返回 nullptr，直接拿来构造 std::string 是未定义行为。
-// 统一经此 helper 读取文本列：NULL 一律按空串处理。
+// sqlite3_column_text 对 NULL 列返回 nullptr，直接构造 std::string 是 UB；统一按空串处理。
 std::string columnText(sqlite3_stmt* stmt, int col)
 {
     const unsigned char* text = sqlite3_column_text(stmt, col);
     return text ? reinterpret_cast<const char*>(text) : std::string();
 }
 
-// 把 t_packets 的一行读进 Packet：queryPacket / queryPackets 共用同一列序，
-// 抽出来消除两处几乎重复的读列逻辑，并统一走 NULL 安全的 columnText。
+// 把 t_packets 一行读进 Packet；queryPacket/queryPackets 共用，统一走 NULL 安全的 columnText。
 std::shared_ptr<Packet> rowToPacket(sqlite3_stmt* stmt)
 {
     std::shared_ptr<Packet> packet = std::make_shared<Packet>();
@@ -580,6 +642,21 @@ bool SQLiteUtil::queryPacket(std::vector<std::shared_ptr<Packet>>& packetList, i
     return true;
 }
 
+// LIKE 模式转义：字面 %/_ 转义（SQL 侧 ESCAPE '\\'），避免用户输入的通配符意外全匹配；
+// * 保留为模糊符（转义在 replace 之前做，故不受影响）。
+std::string escapeLikePattern(const std::string& raw)
+{
+    std::string out;
+    out.reserve(raw.size());
+    for (char c : raw)
+    {
+        if (c == '%' || c == '_' || c == '\\')
+            out.push_back('\\'); // 反斜杠本身也转义，保持模式可预测
+        out.push_back(c);
+    }
+    return out;
+}
+
 std::string SQLiteUtil::buildFuzzyQuery(const std::map<std::string, std::string>& conditions,
                                         std::vector<BindParam>&                   params)
 {
@@ -591,23 +668,25 @@ std::string SQLiteUtil::buildFuzzyQuery(const std::map<std::string, std::string>
         if (condition.first == "mac_address")
         {
             std::string pattern = condition.second;
-            std::replace(pattern.begin(), pattern.end(), '*', '%');
-            // 用 ? 占位、两个源/目的字段各绑定一次，用户输入不进入 SQL 文本
-            sql += " AND (src_mac LIKE ? OR dst_mac LIKE ?)";
+            pattern             = escapeLikePattern(pattern); // 先转义字面 %/_
+            std::replace(pattern.begin(), pattern.end(), '*', '%'); // 再展开模糊符
+            sql += " AND (src_mac LIKE ? ESCAPE '\\' OR dst_mac LIKE ? ESCAPE '\\')";
             params.push_back({BindParam::Text, pattern, 0});
             params.push_back({BindParam::Text, pattern, 0});
         }
         else if (condition.first == "ip_address")
         {
             std::string pattern = condition.second;
+            pattern             = escapeLikePattern(pattern);
             std::replace(pattern.begin(), pattern.end(), '*', '%');
-            sql += " AND (src_ip LIKE ? OR dst_ip LIKE ?)";
+            sql += " AND (src_ip LIKE ? ESCAPE '\\' OR dst_ip LIKE ? ESCAPE '\\')";
             params.push_back({BindParam::Text, pattern, 0});
             params.push_back({BindParam::Text, pattern, 0});
         }
         else if (condition.first == "port")
         {
             std::string pattern = condition.second;
+            pattern             = escapeLikePattern(pattern);
             std::replace(pattern.begin(), pattern.end(), '*', '%');
             // 纯数字则按整数精确匹配，否则按文本模糊匹配（避免 stoi 抛异常）
             bool numeric = !pattern.empty() &&
@@ -622,7 +701,7 @@ std::string SQLiteUtil::buildFuzzyQuery(const std::map<std::string, std::string>
             }
             else
             {
-                sql += " AND (CAST(src_port AS TEXT) LIKE ? OR CAST(dst_port AS TEXT) LIKE ?)";
+                sql += " AND (CAST(src_port AS TEXT) LIKE ? ESCAPE '\\' OR CAST(dst_port AS TEXT) LIKE ? ESCAPE '\\')";
                 params.push_back({BindParam::Text, pattern, 0});
                 params.push_back({BindParam::Text, pattern, 0});
             }
@@ -630,12 +709,11 @@ std::string SQLiteUtil::buildFuzzyQuery(const std::map<std::string, std::string>
         else if (condition.first == "location")
         {
             std::string pattern = condition.second;
+            pattern             = escapeLikePattern(pattern);
             std::replace(pattern.begin(), pattern.end(), '*', '%');
-            // 地理位置一律做任意位置的子串匹配：无条件在前后各加一个 %。
-            // 即使用户输入本身已含 *（如 "湖南*长沙"→"湖南%长沙"），也要补成
-            // "%湖南%长沙%" 才能匹配 "中国-湖南省-长沙市"；多余的 %% 等价单个 %，无害。
+            // 地理位置一律做子串匹配：前后各加一个 %（即便输入已含 *，也要补 %...% 才能匹配）。
             pattern = "%" + pattern + "%";
-            sql += " AND (src_location LIKE ? OR dst_location LIKE ?)";
+            sql += " AND (src_location LIKE ? ESCAPE '\\' OR dst_location LIKE ? ESCAPE '\\')";
             params.push_back({BindParam::Text, pattern, 0});
             params.push_back({BindParam::Text, pattern, 0});
         }
@@ -659,8 +737,7 @@ std::string CommonUtil::packetsToJson(const std::vector<std::shared_ptr<Packet>>
     {
         rapidjson::Value packetObj(rapidjson::kObjectType);
 
-        // 字符串字段使用StringRef引用Packet中已有的内存，避免把每个字符串再拷贝进allocator。
-        // packet在本函数序列化完成前始终存活，不会悬垂。
+        // StringRef 引用 Packet 已有内存，避免再拷贝；packet 在序列化完成前存活，不悬垂。
         packetObj.AddMember("frame_number", rapidjson::Value(packet->frame_number), allocator);
         packetObj.AddMember("time", rapidjson::Value(packet->time), allocator);
         packetObj.AddMember("cap_len", rapidjson::Value(packet->cap_len), allocator);

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -1,0 +1,672 @@
+// EasyTshark Web 前端路由层：把 HTTP 路由、令牌鉴权、Origin 校验、/api/load 路径白名单集中于此，
+// 生产入口与单元测试复用。所有逻辑经 AnalysisSession 门面，本文件只做 HTTP 请求 ↔ 门面调用的装配。
+//
+// 线程：httplib 每连接一线程，处理器可能并发进入；用 opMutex_ 串行化所有写操作（粗粒度锁，
+// 单用户工具足够）；实时抓包回调在抓包线程执行，只推进带独立锁的 liveBuffer_，与 opMutex_ 互不阻塞。
+// 安全：所有 /api/* 须带 X-Auth-Token；浏览器请求还校验 Origin==Host（防 DNS rebinding）；
+// /api/load 仅允许用户主目录或 data/ 下的文件。静态资源不要求 token。
+
+#include <climits>
+#include <cstdlib>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <direct.h> // _fullpath
+#endif
+
+#include "httplib/httplib.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+#include "loguru/loguru.hpp"
+#include "tsharkCommand.hpp"
+#include "tsharkDataType.hpp"
+#include "utils.hpp"
+#include "web/WebServer.hpp"
+
+namespace
+{
+using PacketPtr = std::shared_ptr<Packet>;
+
+// ---- 服务器共享状态 ----
+struct WebState
+{
+    AnalysisSession& session;
+
+    // 访问令牌：所有 /api/* 请求须带 X-Auth-Token 头。
+    std::string token;
+
+    // 串行化所有会改会话状态的处理器，满足门面“写操作需调用方串行化”约定。
+    std::mutex opMutex;
+
+    // 实时抓包缓冲：实时包经 onPacket 回调攒在此（独立锁），前端按 since 增量轮询取走。
+    // 上限 kMaxLiveBuffer：超限丢弃最旧包避免内存无限增长；liveBase 记录已丢弃数，
+    // 使前端 since 绝对序号语义不变。
+    static const size_t kMaxLiveBuffer = 100000;
+    std::mutex          liveMutex;
+    std::deque<PacketPtr> liveBuffer;
+    size_t                liveBase = 0;
+
+    explicit WebState(AnalysisSession& s, std::string tok) : session(s), token(std::move(tok)) {}
+};
+
+// ---- 小工具 ----
+
+void sendJson(httplib::Response& res, const std::string& body, int status = 200)
+{
+    res.status = status;
+    res.set_content(body, "application/json; charset=utf-8");
+}
+
+// 统一的错误响应：{"error":"..."}（消息里的引号 / 反斜杠做最小转义，避免拼坏 JSON）。
+void sendError(httplib::Response& res, const std::string& msg, int status = 500)
+{
+    std::string escaped;
+    escaped.reserve(msg.size() + 8);
+    for (char c : msg)
+    {
+        if (c == '"' || c == '\\')
+            escaped.push_back('\\');
+        if (c == '\n' || c == '\r' || c == '\t')
+            escaped.push_back(' ');
+        else
+            escaped.push_back(c);
+    }
+    sendJson(res, "{\"error\":\"" + escaped + "\"}", status);
+}
+
+// 访问令牌校验：/api/* 须带 X-Auth-Token 且与令牌一致。静态资源不带 token，不受影响。
+bool authorized(const httplib::Request& req, const std::string& token)
+{
+    const std::string& got = req.get_header_value("X-Auth-Token");
+    if (token.empty() || got.size() != token.size())
+        return false;
+    // 恒定时间比较：逐字节累积异或，不因首个不同字节而提前返回，消除计时侧信道。
+    unsigned char diff = 0;
+    for (size_t i = 0; i < token.size(); ++i)
+        diff |= static_cast<unsigned char>(got[i] ^ token[i]);
+    return diff == 0;
+}
+
+// 浏览器跨站防御：带 Origin 头时其 host 必须与 Host 头一致，否则视为 DNS rebinding 拒绝。
+// 非浏览器（curl）无 Origin 头，仍须通过 token 校验。
+bool originAllowed(const httplib::Request& req)
+{
+    const std::string& origin = req.get_header_value("Origin");
+    if (origin.empty() || origin == "null") // 无 Origin（curl）或 file:// 打开的页面
+        return true;                        // （后者仍过不了 token 校验）
+    const std::string& host = req.get_header_value("Host");
+    if (host.empty())
+        return false;
+    // Origin 形如 http://host:port 或 https://host:port，取 "//" 后的 host[:port] 部分
+    size_t scheme = origin.find("://");
+    std::string originHost =
+        scheme == std::string::npos ? origin : origin.substr(scheme + 3);
+    // 去掉可能的尾部 '/'（Origin 规范不带，但防御性处理）
+    while (!originHost.empty() && originHost.back() == '/')
+        originHost.pop_back();
+    return originHost == host;
+}
+
+// 把路径规范为绝对路径（POSIX realpath，Windows _fullpath）；文件不存在时返回空串。
+std::string normalizePath(const std::string& p)
+{
+    if (p.empty())
+        return std::string();
+#if defined(_WIN32)
+    char buf[MAX_PATH];
+    if (_fullpath(buf, p.c_str(), MAX_PATH) != nullptr)
+        return std::string(buf);
+    return std::string();
+#else
+    char buf[PATH_MAX];
+    if (realpath(p.c_str(), buf) != nullptr)
+        return std::string(buf);
+    return std::string();
+#endif
+}
+
+// 路径前缀匹配：abs 等于 root，或以 root + 路径分隔符开头。
+bool pathUnder(const std::string& abs, const std::string& root)
+{
+    if (abs == root)
+        return true;
+    if (root.empty() || abs.size() <= root.size())
+        return false;
+#if defined(_WIN32)
+    bool sep = abs[root.size()] == '\\' || abs[root.size()] == '/';
+#else
+    bool sep = abs[root.size()] == '/';
+#endif
+    return sep && abs.compare(0, root.size(), root) == 0;
+}
+
+// /api/load 路径白名单：只允许用户主目录或 data/ 下的文件，避免任意文件被读取解析。
+bool isPathAllowed(const std::string& p)
+{
+    std::string abs = normalizePath(p);
+    if (abs.empty())
+    {
+        // 文件不存在时回退检查父目录归属（realpath 对不存在路径失败，但越权判断只看路径归属）。
+        size_t slash = p.find_last_of("/\\");
+        if (slash == std::string::npos)
+            return false;
+        abs = normalizePath(p.substr(0, slash));
+        if (abs.empty())
+            return false;
+    }
+#if defined(_WIN32)
+    std::string home;
+    if (const char* h = std::getenv("USERPROFILE"))
+        home = h;
+#else
+    std::string home;
+    if (const char* h = std::getenv("HOME"))
+        home = h;
+#endif
+    if (!home.empty() && pathUnder(abs, home))
+        return true;
+    std::string dataAbs = normalizePath("data");
+    return !dataAbs.empty() && pathUnder(abs, dataAbs);
+}
+
+// 解析请求体 JSON；失败返回 false。空体按空对象处理（无字段即可）。
+bool parseBody(const httplib::Request& req, rapidjson::Document& doc)
+{
+    if (req.body.empty())
+    {
+        doc.SetObject();
+        return true;
+    }
+    doc.Parse(req.body.c_str());
+    return !doc.HasParseError() && doc.IsObject();
+}
+
+// 取字符串字段；不存在或类型不符时置空串。
+std::string jsonStr(const rapidjson::Document& doc, const char* key)
+{
+    if (doc.HasMember(key) && doc[key].IsString())
+        return doc[key].GetString();
+    return std::string();
+}
+
+// 把协议分层树递归序列化成 rapidjson 值：{label,value,children:[...]}。
+rapidjson::Value detailToJson(const DetailNode& node, rapidjson::Document::AllocatorType& alloc)
+{
+    rapidjson::Value obj(rapidjson::kObjectType);
+    obj.AddMember("label", rapidjson::Value(node.label.c_str(), alloc), alloc);
+    obj.AddMember("value", rapidjson::Value(node.value.c_str(), alloc), alloc);
+
+    rapidjson::Value children(rapidjson::kArrayType);
+    for (const DetailNode& child : node.children)
+        children.PushBack(detailToJson(child, alloc), alloc);
+    obj.AddMember("children", children, alloc);
+    return obj;
+}
+
+std::string toHexString(const std::vector<unsigned char>& bytes)
+{
+    static const char* kHex = "0123456789abcdef";
+    std::string        out;
+    out.reserve(bytes.size() * 2);
+    for (unsigned char b : bytes)
+    {
+        out.push_back(kHex[b >> 4]);
+        out.push_back(kHex[b & 0x0f]);
+    }
+    return out;
+}
+
+// ---- 路由注册 ----
+
+void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
+{
+    // 全局鉴权（pre-routing）：/api/* 须通过 token + Origin 双重校验；静态资源放行。
+    svr.set_pre_routing_handler([st](const httplib::Request& req, httplib::Response& res)
+    {
+        if (req.path.compare(0, 5, "/api/") != 0 && req.path != "/api")
+            return httplib::Server::HandlerResponse::Unhandled; // 静态资源放行
+        if (!authorized(req, st->token))
+        {
+            sendError(res, "未授权：请提供 X-Auth-Token 头（令牌见服务器启动输出）", 401);
+            return httplib::Server::HandlerResponse::Handled;
+        }
+        if (!originAllowed(req))
+        {
+            sendError(res, "跨站请求被拒绝：Origin 与 Host 不一致", 403);
+            return httplib::Server::HandlerResponse::Handled;
+        }
+        return httplib::Server::HandlerResponse::Unhandled;
+    });
+
+    // 服务运行状态：前端轮询用（实时抓包时据此拉取增量、更新计数）。
+    svr.Get("/api/status", [st](const httplib::Request&, httplib::Response& res)
+    {
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        size_t                      liveCount;
+        {
+            std::lock_guard<std::mutex> llk(st->liveMutex);
+            liveCount = st->liveBuffer.size();
+        }
+        std::string body = "{\"capturing\":" +
+                           std::string(st->session.isCapturing() ? "true" : "false") +
+                           ",\"count\":" + std::to_string(st->session.packetCount()) +
+                           ",\"live\":" + std::to_string(liveCount) + "}";
+        sendJson(res, body);
+    });
+
+    // 报文列表三种模式：?since=N 取实时缓冲增量（N 为绝对序号，丢旧包时后端自动对齐）；
+    //   ?page=P&pageSize=S 分页返回快照切片；无参数返回完整快照。
+    svr.Get("/api/packets", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        if (req.has_param("since"))
+        {
+            size_t since = static_cast<size_t>(std::strtoul(req.get_param_value("since").c_str(),
+                                                            nullptr, 10));
+            std::vector<PacketPtr> slice;
+            {
+                std::lock_guard<std::mutex> llk(st->liveMutex);
+                size_t start = since >= st->liveBase ? since - st->liveBase : 0;
+                if (start < st->liveBuffer.size())
+                    slice.assign(st->liveBuffer.begin() + start, st->liveBuffer.end());
+            }
+            sendJson(res, CommonUtil::packetsToJson(slice));
+            return;
+        }
+
+        if (req.has_param("page"))
+        {
+            long page = std::strtol(req.get_param_value("page").c_str(), nullptr, 10);
+            long pageSize =
+                req.has_param("pageSize")
+                    ? std::strtol(req.get_param_value("pageSize").c_str(), nullptr, 10)
+                    : 100;
+            if (page < 0)
+                page = 0;
+            if (pageSize < 1)
+                pageSize = 1;
+            if (pageSize > 1000)
+                pageSize = 1000; // 单页上限，防手滑拉爆
+
+            std::lock_guard<std::mutex> lk(st->opMutex);
+            auto                        snap = st->session.packetsSnapshot();
+            if (!snap)
+            {
+                sendJson(res,
+                         "{\"total\":0,\"page\":0,\"pageSize\":" + std::to_string(pageSize) +
+                             ",\"packets\":[]}");
+                return;
+            }
+            size_t total = snap->size();
+            size_t begin = static_cast<size_t>(page) * pageSize;
+            if (begin >= total)
+            {
+                begin = 0; // 越界（如删除后页码失效）回首页
+                page  = 0;
+            }
+            size_t end = std::min(total, begin + static_cast<size_t>(pageSize));
+            std::vector<PacketPtr> slice(snap->begin() + begin, snap->begin() + end);
+
+            // 用 rapidjson 组装 {total,page,pageSize,packets:[...]}，packets 复用 packetsToJson 结果。
+            rapidjson::Document doc;
+            doc.SetObject();
+            doc.AddMember("total", static_cast<uint64_t>(total), doc.GetAllocator());
+            doc.AddMember("page", static_cast<int>(page), doc.GetAllocator());
+            doc.AddMember("pageSize", static_cast<int>(pageSize), doc.GetAllocator());
+            rapidjson::Document innerDoc;
+            innerDoc.Parse(CommonUtil::packetsToJson(slice).c_str());
+            rapidjson::Value packetsVal;
+            packetsVal.CopyFrom(innerDoc["packets"], doc.GetAllocator());
+            doc.AddMember("packets", packetsVal, doc.GetAllocator());
+            rapidjson::StringBuffer                    buf;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+            doc.Accept(writer);
+            sendJson(res, buf.GetString());
+            return;
+        }
+
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        auto                        snap = st->session.packetsSnapshot();
+        sendJson(res, CommonUtil::packetsToJson(*snap));
+    });
+
+    // 指定帧号的原始字节（十六进制视图）。
+    svr.Get(R"(/api/hex/(\d+))", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        // 用 strtoul 而非会抛 out_of_range 的 stoul：超长数字串越界返回 ULONG_MAX，自然走 404。
+        uint32_t                    frame =
+            static_cast<uint32_t>(std::strtoul(req.matches[1].str().c_str(), nullptr, 10));
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        std::vector<unsigned char>  bytes;
+        if (!st->session.getHex(frame, bytes))
+        {
+            sendError(res, "取十六进制失败（帧不存在或文件未就绪）", 404);
+            return;
+        }
+        sendJson(res, "{\"frame\":" + std::to_string(frame) + ",\"hex\":\"" + toHexString(bytes) +
+                          "\"}");
+    });
+
+    // 指定帧号的协议分层树（详情面板）。
+    svr.Get(R"(/api/detail/(\d+))", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        uint32_t                    frame =
+            static_cast<uint32_t>(std::strtoul(req.matches[1].str().c_str(), nullptr, 10));
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        DetailNode                  root;
+        if (!st->session.getDetailTree(frame, root))
+        {
+            sendError(res, "解析协议详情失败（帧不存在或文件未就绪）", 404);
+            return;
+        }
+        rapidjson::Document doc;
+        doc.SetObject();
+        rapidjson::Value tree = detailToJson(root, doc.GetAllocator());
+        doc.AddMember("detail", tree, doc.GetAllocator());
+        rapidjson::StringBuffer                    buf;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+        doc.Accept(writer);
+        sendJson(res, buf.GetString());
+    });
+
+    // 载入并解析服务器本地的一个 pcap 文件（注意：路径在服务器端文件系统解析）。
+    svr.Post("/api/load", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string path = jsonStr(doc, "path");
+        if (path.empty())
+        {
+            sendError(res, "缺少 path 字段", 400);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        // 路径白名单：只允许载入用户主目录 / data/ 下的文件，避免任意文件被读取。
+        if (!isPathAllowed(path))
+        {
+            sendError(res, "路径不在允许范围内（仅限用户主目录或 data/ 下的文件）", 403);
+            return;
+        }
+        try
+        {
+            if (!st->session.loadPcap(path))
+            {
+                sendError(res, "载入/解析 pcap 失败");
+                return;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("载入失败：") + e.what());
+            return;
+        }
+        sendJson(res, "{\"ok\":true,\"count\":" + std::to_string(st->session.packetCount()) + "}");
+    });
+
+    // tshark 显示过滤（-Y）：在当前报文集上按表达式筛选，返回命中的子集。
+    svr.Post("/api/filter", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string expr = jsonStr(doc, "expr");
+        if (expr.empty())
+        {
+            sendError(res, "缺少 expr 字段", 400);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        std::vector<PacketPtr>      out;
+        std::string                 filterErr;
+        try
+        {
+            if (!st->session.queryDisplayFilter(expr, out, &filterErr))
+            {
+                // 透传 tshark 的具体报错（如字段名拼错），比笼统的“过滤失败”有用得多
+                sendError(res, filterErr.empty() ? std::string("过滤失败（表达式非法或文件未就绪）")
+                                                 : std::string("过滤失败：") + filterErr);
+                return;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("过滤失败：") + e.what());
+            return;
+        }
+        sendJson(res, CommonUtil::packetsToJson(out));
+    });
+
+    // 结构化查询（MAC/IP/端口/归属地，参数化防注入）。门面 query() 已直接返回 JSON，透传。
+    svr.Post("/api/query", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::map<std::string, std::string> cond;
+        const char* keys[] = {"mac_address", "ip_address", "port", "location"};
+        for (const char* k : keys)
+        {
+            std::string v = jsonStr(doc, k);
+            if (!v.empty())
+                cond[k] = v;
+        }
+        if (cond.empty())
+        {
+            sendError(res, "未指定任何查询条件", 400);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        std::string                 jsonResult;
+        if (!st->session.query(cond, jsonResult))
+        {
+            sendError(res, "查询失败（是否已载入 pcap？）");
+            return;
+        }
+        sendJson(res, jsonResult);
+    });
+
+    // 网卡列表（实时抓包用）。listAdapters 会启动 tshark，未安装时抛异常，须兜住。
+    svr.Get("/api/adapters", [st](const httplib::Request&, httplib::Response& res)
+    {
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        try
+        {
+            std::vector<AdapterInfo> adapters = st->session.listAdapters();
+            rapidjson::Document      doc;
+            doc.SetArray();
+            rapidjson::Document::AllocatorType& alloc = doc.GetAllocator();
+            for (const AdapterInfo& a : adapters)
+            {
+                rapidjson::Value obj(rapidjson::kObjectType);
+                obj.AddMember("id", a.id, alloc);
+                obj.AddMember("name", rapidjson::Value(a.name.c_str(), alloc), alloc);
+                obj.AddMember("remark", rapidjson::Value(a.remark.c_str(), alloc), alloc);
+                doc.PushBack(obj, alloc);
+            }
+            rapidjson::StringBuffer                    buf;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+            doc.Accept(writer);
+            sendJson(res, buf.GetString());
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("获取网卡失败：") + e.what() + "（请确认已安装 Wireshark）");
+        }
+    });
+
+    // 开始实时抓包：清空 live 缓冲，回调把每个包推进缓冲（前端按 since 增量轮询）。
+    svr.Post("/api/capture/start", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string adapter = jsonStr(doc, "adapter");
+        if (adapter.empty())
+        {
+            sendError(res, "缺少 adapter 字段", 400);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        if (st->session.isCapturing())
+        {
+            sendError(res, "已在抓包中", 409);
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> llk(st->liveMutex);
+            st->liveBuffer.clear();
+            st->liveBase = 0;
+        }
+        WebState* sp = st.get(); // 回调在抓包线程执行：只把包推进带锁缓冲，绝不碰其它状态
+        bool      ok = false;
+        try
+        {
+            ok = st->session.startLiveCapture(adapter, [sp](const PacketPtr& p)
+            {
+                std::lock_guard<std::mutex> llk(sp->liveMutex);
+                sp->liveBuffer.push_back(p);
+                // 上限：每包至多丢弃 1 个最旧包，deque::pop_front 为 O(1)
+                if (sp->liveBuffer.size() > WebState::kMaxLiveBuffer)
+                {
+                    sp->liveBuffer.pop_front();
+                    ++sp->liveBase;
+                }
+            });
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("启动抓包失败：") + e.what());
+            return;
+        }
+        if (!ok)
+        {
+            sendError(res, "启动抓包失败（检查网卡 / 抓包权限）");
+            return;
+        }
+        sendJson(res, "{\"ok\":true}");
+    });
+
+    // 停止抓包并解析入库：完成后 packetsSnapshot() 才有完整结果、hex/详情才可用。
+    svr.Post("/api/capture/stop", [st](const httplib::Request&, httplib::Response& res)
+    {
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        try
+        {
+            if (!st->session.stopLiveCapture())
+            {
+                sendError(res, "停止抓包或解析失败");
+                return;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("停止失败：") + e.what());
+            return;
+        }
+        sendJson(res, "{\"ok\":true,\"count\":" + std::to_string(st->session.packetCount()) + "}");
+    });
+
+    // tshark 路径：GET 查看当前解析到的路径与可用性；POST 手动指定（无需重编译）。
+    svr.Get("/api/tshark", [st](const httplib::Request&, httplib::Response& res)
+    {
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        std::string                 path      = st->session.tsharkPath();
+        bool                        available = TsharkCommand::tsharkAvailable(path);
+        std::string                 escaped;
+        for (char c : path)
+        {
+            if (c == '"' || c == '\\')
+                escaped.push_back('\\');
+            escaped.push_back(c);
+        }
+        sendJson(res, "{\"path\":\"" + escaped + "\",\"available\":" +
+                          (available ? "true" : "false") + ",\"engine\":\"" +
+                          st->session.engineName() + "\"}");
+    });
+
+    svr.Post("/api/tshark", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string path = jsonStr(doc, "path");
+        if (path.empty())
+        {
+            sendError(res, "缺少 path 字段", 400);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        st->session.setTsharkPath(path);
+        bool available = TsharkCommand::tsharkAvailable(path);
+        sendJson(res, "{\"ok\":true,\"available\":" + std::string(available ? "true" : "false") +
+                          "}");
+    });
+
+    // 导出当前报文快照为 CSV（服务器端路径），供 Excel / 数据分析工具二次加工。
+    // 路径同样受白名单约束（只写用户主目录或 data/ 下）。
+    svr.Post("/api/export/csv", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string path = jsonStr(doc, "path");
+        if (path.empty())
+        {
+            sendError(res, "缺少 path 字段", 400);
+            return;
+        }
+        if (!isPathAllowed(path))
+        {
+            sendError(res, "路径不在允许范围内（仅限用户主目录或 data/ 下的文件）", 403);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        try
+        {
+            if (!st->session.exportPacketsCsv(path))
+            {
+                sendError(res, "导出 CSV 失败（是否已载入 pcap？）");
+                return;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("导出 CSV 失败：") + e.what());
+            return;
+        }
+        sendJson(res, "{\"ok\":true,\"path\":\"" + path + "\"}");
+    });
+}
+} // namespace
+
+void registerWebRoutes(httplib::Server& svr, AnalysisSession& session,
+                       const std::string& token)
+{
+    std::shared_ptr<WebState> state(new WebState(session, token));
+    registerRoutes(svr, state);
+}

--- a/src/web/main_web.cpp
+++ b/src/web/main_web.cpp
@@ -1,444 +1,24 @@
-// EasyTshark Web 前端入口
-//
-// 第三个前端（与 CLI 的 main.cpp、GUI 的 gui/main_gui.cpp 并列）：用 cpp-httplib 起一个
-// HTTP 服务，对外暴露 REST/JSON API，并托管 web/ 下的纯 HTML/JS 前端。所有抓包 / 解析 /
-// 入库 / 查询逻辑仍然只经 AnalysisSession 门面——本文件只做“HTTP 请求 ↔ 门面调用”的装配，
-// 不碰任何 tshark / 数据库细节。这样引擎可跑在无图形界面的机器上，用户从浏览器远程访问。
-//
-// 线程约定：httplib 每个连接一个线程，处理器可能并发进入。门面约定“快照读线程安全，但
-// 载入/抓包等写操作需调用方串行化”，故这里用一把 opMutex_ 把所有会改会话状态的处理器串起来
-// （单用户分析工具吞吐无压力，粗粒度锁最简单也最安全）。实时抓包的回调在抓包线程执行，只把
-// 包推进带独立锁的 liveBuffer_，与 opMutex_ 互不阻塞。
-//
-// 安全：默认只绑 127.0.0.1，远程访问请走 SSH 端口转发，不要裸绑 0.0.0.0（本服务会驱动
-// 特权抓包）。可用命令行参数或环境变量覆盖 host/port。
+// EasyTshark Web 前端入口：解析参数、定位 tshark、启动 HTTP 服务并托管 web/ 静态前端。
+// 路由逻辑在 web/WebServer.cpp（registerWebRoutes），本文件只做入口装配。
 
 #include <cstdlib>
-#include <map>
-#include <memory>
-#include <mutex>
+#include <random>
 #include <string>
-#include <vector>
+
+#if defined(_WIN32)
+#include <direct.h> // _fullpath
+#endif
 
 #include "httplib/httplib.h"
-#include "rapidjson/document.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
 
 #include "AnalysisSession.hpp"
 #include "loguru/loguru.hpp"
 #include "tsharkCommand.hpp"
-#include "tsharkDataType.hpp"
-#include "utils.hpp"
+#include "web/WebServer.hpp"
 
 namespace
 {
-using PacketPtr = std::shared_ptr<Packet>;
-
-// ---- 服务器共享状态 ----
-struct WebState
-{
-    AnalysisSession& session;
-
-    // 串行化所有会改会话状态（载入 / 抓包 / 过滤 / 查询 / 取详情）的处理器，满足门面的
-    // “写操作需调用方串行化”约定；同时避免并发处理器交叉驱动 analyzer_/tshark 子进程。
-    std::mutex opMutex;
-
-    // 实时抓包缓冲：抓包途中 packetsSnapshot() 为空，实时包只经 onPacket 回调而来，
-    // 先攒在这里（独立锁），前端按 since 增量轮询取走（对应 GUI 的 liveIncoming/drainLive）。
-    std::mutex             liveMutex;
-    std::vector<PacketPtr> liveBuffer;
-
-    explicit WebState(AnalysisSession& s) : session(s) {}
-};
-
-// ---- 小工具 ----
-
-void sendJson(httplib::Response& res, const std::string& body, int status = 200)
-{
-    res.status = status;
-    res.set_content(body, "application/json; charset=utf-8");
-}
-
-// 统一的错误响应：{"error":"..."}（消息里的引号 / 反斜杠做最小转义，避免拼坏 JSON）。
-void sendError(httplib::Response& res, const std::string& msg, int status = 500)
-{
-    std::string escaped;
-    escaped.reserve(msg.size() + 8);
-    for (char c : msg)
-    {
-        if (c == '"' || c == '\\')
-            escaped.push_back('\\');
-        if (c == '\n' || c == '\r' || c == '\t')
-            escaped.push_back(' ');
-        else
-            escaped.push_back(c);
-    }
-    sendJson(res, "{\"error\":\"" + escaped + "\"}", status);
-}
-
-// 解析请求体 JSON；失败返回 false。空体按空对象处理（无字段即可）。
-bool parseBody(const httplib::Request& req, rapidjson::Document& doc)
-{
-    if (req.body.empty())
-    {
-        doc.SetObject();
-        return true;
-    }
-    doc.Parse(req.body.c_str());
-    return !doc.HasParseError() && doc.IsObject();
-}
-
-// 取字符串字段；不存在或类型不符时置空串。
-std::string jsonStr(const rapidjson::Document& doc, const char* key)
-{
-    if (doc.HasMember(key) && doc[key].IsString())
-        return doc[key].GetString();
-    return std::string();
-}
-
-// 把协议分层树递归序列化成 rapidjson 值：{label,value,children:[...]}。
-// DetailNode 只承载展示文本，这里逐层拷贝即可（详情单包解析，规模小，不必用 StringRef）。
-rapidjson::Value detailToJson(const DetailNode& node, rapidjson::Document::AllocatorType& alloc)
-{
-    rapidjson::Value obj(rapidjson::kObjectType);
-    obj.AddMember("label", rapidjson::Value(node.label.c_str(), alloc), alloc);
-    obj.AddMember("value", rapidjson::Value(node.value.c_str(), alloc), alloc);
-
-    rapidjson::Value children(rapidjson::kArrayType);
-    for (const DetailNode& child : node.children)
-        children.PushBack(detailToJson(child, alloc), alloc);
-    obj.AddMember("children", children, alloc);
-    return obj;
-}
-
-std::string toHexString(const std::vector<unsigned char>& bytes)
-{
-    static const char* kHex = "0123456789abcdef";
-    std::string        out;
-    out.reserve(bytes.size() * 2);
-    for (unsigned char b : bytes)
-    {
-        out.push_back(kHex[b >> 4]);
-        out.push_back(kHex[b & 0x0f]);
-    }
-    return out;
-}
-
-// ---- 路由注册 ----
-
-void registerRoutes(httplib::Server& svr, WebState& st)
-{
-    // 服务运行状态：前端轮询用（实时抓包时据此拉取增量、更新计数）。
-    svr.Get("/api/status", [&st](const httplib::Request&, httplib::Response& res)
-    {
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        size_t                      liveCount;
-        {
-            std::lock_guard<std::mutex> llk(st.liveMutex);
-            liveCount = st.liveBuffer.size();
-        }
-        std::string body = "{\"capturing\":" +
-                           std::string(st.session.isCapturing() ? "true" : "false") +
-                           ",\"count\":" + std::to_string(st.session.packetCount()) +
-                           ",\"live\":" + std::to_string(liveCount) + "}";
-        sendJson(res, body);
-    });
-
-    // 报文列表：
-    //   - 带 ?since=N：返回实时缓冲区中下标 N 起的增量（抓包途中用）。
-    //   - 不带 since：返回已解析入库后的完整快照（离线 / 抓包停止后）。
-    // 两条路径都复用 CommonUtil::packetsToJson，与 CLI/GUI 的查询序列化同一份字段约定。
-    svr.Get("/api/packets", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        if (req.has_param("since"))
-        {
-            size_t since = static_cast<size_t>(std::strtoul(req.get_param_value("since").c_str(),
-                                                            nullptr, 10));
-            std::vector<PacketPtr>      slice;
-            {
-                std::lock_guard<std::mutex> llk(st.liveMutex);
-                if (since < st.liveBuffer.size())
-                    slice.assign(st.liveBuffer.begin() + since, st.liveBuffer.end());
-            }
-            sendJson(res, CommonUtil::packetsToJson(slice));
-            return;
-        }
-
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        sendJson(res, CommonUtil::packetsToJson(st.session.packetsSnapshot()));
-    });
-
-    // 指定帧号的原始字节（十六进制视图）。
-    svr.Get(R"(/api/hex/(\d+))", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        uint32_t                    frame = static_cast<uint32_t>(std::stoul(req.matches[1]));
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        std::vector<unsigned char>  bytes;
-        if (!st.session.getHex(frame, bytes))
-        {
-            sendError(res, "取十六进制失败（帧不存在或文件未就绪）", 404);
-            return;
-        }
-        sendJson(res, "{\"frame\":" + std::to_string(frame) + ",\"hex\":\"" + toHexString(bytes) +
-                          "\"}");
-    });
-
-    // 指定帧号的协议分层树（详情面板）。
-    svr.Get(R"(/api/detail/(\d+))", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        uint32_t                    frame = static_cast<uint32_t>(std::stoul(req.matches[1]));
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        DetailNode                  root;
-        if (!st.session.getDetailTree(frame, root))
-        {
-            sendError(res, "解析协议详情失败（帧不存在或文件未就绪）", 404);
-            return;
-        }
-        rapidjson::Document doc;
-        doc.SetObject();
-        rapidjson::Value tree = detailToJson(root, doc.GetAllocator());
-        doc.AddMember("detail", tree, doc.GetAllocator());
-        rapidjson::StringBuffer                    buf;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-        doc.Accept(writer);
-        sendJson(res, buf.GetString());
-    });
-
-    // 载入并解析服务器本地的一个 pcap 文件（注意：路径在服务器端文件系统解析）。
-    svr.Post("/api/load", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        rapidjson::Document doc;
-        if (!parseBody(req, doc))
-        {
-            sendError(res, "请求体不是合法 JSON", 400);
-            return;
-        }
-        std::string path = jsonStr(doc, "path");
-        if (path.empty())
-        {
-            sendError(res, "缺少 path 字段", 400);
-            return;
-        }
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        try
-        {
-            if (!st.session.loadPcap(path))
-            {
-                sendError(res, "载入/解析 pcap 失败");
-                return;
-            }
-        }
-        catch (const std::exception& e)
-        {
-            sendError(res, std::string("载入失败：") + e.what());
-            return;
-        }
-        sendJson(res, "{\"ok\":true,\"count\":" + std::to_string(st.session.packetCount()) + "}");
-    });
-
-    // tshark 显示过滤（-Y）：在当前报文集上按表达式筛选，返回命中的子集。
-    svr.Post("/api/filter", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        rapidjson::Document doc;
-        if (!parseBody(req, doc))
-        {
-            sendError(res, "请求体不是合法 JSON", 400);
-            return;
-        }
-        std::string expr = jsonStr(doc, "expr");
-        if (expr.empty())
-        {
-            sendError(res, "缺少 expr 字段", 400);
-            return;
-        }
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        std::vector<PacketPtr>      out;
-        try
-        {
-            if (!st.session.queryDisplayFilter(expr, out))
-            {
-                sendError(res, "过滤失败（表达式非法或文件未就绪）");
-                return;
-            }
-        }
-        catch (const std::exception& e)
-        {
-            sendError(res, std::string("过滤失败：") + e.what());
-            return;
-        }
-        sendJson(res, CommonUtil::packetsToJson(out));
-    });
-
-    // 结构化查询（MAC/IP/端口/归属地，参数化防注入）。门面 query() 已直接返回 JSON，透传。
-    svr.Post("/api/query", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        rapidjson::Document doc;
-        if (!parseBody(req, doc))
-        {
-            sendError(res, "请求体不是合法 JSON", 400);
-            return;
-        }
-        std::map<std::string, std::string> cond;
-        const char* keys[] = {"mac_address", "ip_address", "port", "location"};
-        for (const char* k : keys)
-        {
-            std::string v = jsonStr(doc, k);
-            if (!v.empty())
-                cond[k] = v;
-        }
-        if (cond.empty())
-        {
-            sendError(res, "未指定任何查询条件", 400);
-            return;
-        }
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        std::string                 jsonResult;
-        if (!st.session.query(cond, jsonResult))
-        {
-            sendError(res, "查询失败（是否已载入 pcap？）");
-            return;
-        }
-        sendJson(res, jsonResult);
-    });
-
-    // 网卡列表（实时抓包用）。listAdapters 会启动 tshark，未安装时抛异常，须兜住。
-    svr.Get("/api/adapters", [&st](const httplib::Request&, httplib::Response& res)
-    {
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        try
-        {
-            std::vector<AdapterInfo> adapters = st.session.listAdapters();
-            rapidjson::Document      doc;
-            doc.SetArray();
-            rapidjson::Document::AllocatorType& alloc = doc.GetAllocator();
-            for (const AdapterInfo& a : adapters)
-            {
-                rapidjson::Value obj(rapidjson::kObjectType);
-                obj.AddMember("id", a.id, alloc);
-                obj.AddMember("name", rapidjson::Value(a.name.c_str(), alloc), alloc);
-                obj.AddMember("remark", rapidjson::Value(a.remark.c_str(), alloc), alloc);
-                doc.PushBack(obj, alloc);
-            }
-            rapidjson::StringBuffer                    buf;
-            rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-            doc.Accept(writer);
-            sendJson(res, buf.GetString());
-        }
-        catch (const std::exception& e)
-        {
-            sendError(res, std::string("获取网卡失败：") + e.what() + "（请确认已安装 Wireshark）");
-        }
-    });
-
-    // 开始实时抓包：清空 live 缓冲，回调把每个包推进缓冲（前端按 since 增量轮询）。
-    svr.Post("/api/capture/start", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        rapidjson::Document doc;
-        if (!parseBody(req, doc))
-        {
-            sendError(res, "请求体不是合法 JSON", 400);
-            return;
-        }
-        std::string adapter = jsonStr(doc, "adapter");
-        if (adapter.empty())
-        {
-            sendError(res, "缺少 adapter 字段", 400);
-            return;
-        }
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        if (st.session.isCapturing())
-        {
-            sendError(res, "已在抓包中", 409);
-            return;
-        }
-        {
-            std::lock_guard<std::mutex> llk(st.liveMutex);
-            st.liveBuffer.clear();
-        }
-        WebState* sp = &st; // 回调在抓包线程执行：只把包推进带锁缓冲，绝不碰其它状态
-        bool      ok = false;
-        try
-        {
-            ok = st.session.startLiveCapture(adapter, [sp](const PacketPtr& p)
-            {
-                std::lock_guard<std::mutex> llk(sp->liveMutex);
-                sp->liveBuffer.push_back(p);
-            });
-        }
-        catch (const std::exception& e)
-        {
-            sendError(res, std::string("启动抓包失败：") + e.what());
-            return;
-        }
-        if (!ok)
-        {
-            sendError(res, "启动抓包失败（检查网卡 / 抓包权限）");
-            return;
-        }
-        sendJson(res, "{\"ok\":true}");
-    });
-
-    // 停止抓包并解析入库：完成后 packetsSnapshot() 才有完整结果、hex/详情才可用。
-    svr.Post("/api/capture/stop", [&st](const httplib::Request&, httplib::Response& res)
-    {
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        try
-        {
-            if (!st.session.stopLiveCapture())
-            {
-                sendError(res, "停止抓包或解析失败");
-                return;
-            }
-        }
-        catch (const std::exception& e)
-        {
-            sendError(res, std::string("停止失败：") + e.what());
-            return;
-        }
-        sendJson(res, "{\"ok\":true,\"count\":" + std::to_string(st.session.packetCount()) + "}");
-    });
-
-    // tshark 路径：GET 查看当前解析到的路径与可用性；POST 手动指定（无需重编译）。
-    svr.Get("/api/tshark", [&st](const httplib::Request&, httplib::Response& res)
-    {
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        std::string                 path      = st.session.tsharkPath();
-        bool                        available = TsharkCommand::tsharkAvailable(path);
-        std::string                 escaped;
-        for (char c : path)
-        {
-            if (c == '"' || c == '\\')
-                escaped.push_back('\\');
-            escaped.push_back(c);
-        }
-        sendJson(res, "{\"path\":\"" + escaped + "\",\"available\":" +
-                          (available ? "true" : "false") + "}");
-    });
-
-    svr.Post("/api/tshark", [&st](const httplib::Request& req, httplib::Response& res)
-    {
-        rapidjson::Document doc;
-        if (!parseBody(req, doc))
-        {
-            sendError(res, "请求体不是合法 JSON", 400);
-            return;
-        }
-        std::string path = jsonStr(doc, "path");
-        if (path.empty())
-        {
-            sendError(res, "缺少 path 字段", 400);
-            return;
-        }
-        std::lock_guard<std::mutex> lk(st.opMutex);
-        st.session.setTsharkPath(path);
-        bool available = TsharkCommand::tsharkAvailable(path);
-        sendJson(res, "{\"ok\":true,\"available\":" + std::string(available ? "true" : "false") +
-                          "}");
-    });
-}
-
-// 在若干候选目录里找到静态前端目录（源码树 web/ 与产物 output/web 都可能是运行时 cwd 的相对位置）。
+// 在候选目录里找到静态前端目录（源码树 web/ 与产物 output/web 都可能相对 cwd）。
 std::string resolveWebRoot()
 {
     const char* candidates[] = {"web", "output/web", "./web"};
@@ -455,7 +35,6 @@ std::string resolveWebRoot()
     }
     return "web"; // 兜底：即便未找到也返回默认值，静态挂载失败仅影响页面、不影响 API
 }
-
 } // namespace
 
 int main(int argc, char* argv[])
@@ -464,11 +43,15 @@ int main(int argc, char* argv[])
     // 覆盖优先级：命令行参数 > 环境变量 > 默认值。
     std::string host = "127.0.0.1";
     int         port = 8080;
+    // 访问令牌：环境变量 EASYTSHARK_WEB_TOKEN 或 --token 指定；未指定则随机生成并打印。
+    std::string token;
 
     if (const char* h = std::getenv("EASYTSHARK_WEB_HOST"))
         host = h;
     if (const char* p = std::getenv("EASYTSHARK_WEB_PORT"))
         port = std::atoi(p);
+    if (const char* t = std::getenv("EASYTSHARK_WEB_TOKEN"))
+        token = t;
     for (int i = 1; i + 1 < argc; i += 2)
     {
         std::string flag = argv[i];
@@ -476,7 +59,21 @@ int main(int argc, char* argv[])
             host = argv[i + 1];
         else if (flag == "--port")
             port = std::atoi(argv[i + 1]);
+        else if (flag == "--token")
+            token = argv[i + 1];
     }
+
+    if (token.empty())
+    {
+        // 随机生成 32 个十六进制字符（128 位熵）。
+        std::random_device rd;
+        std::string        hex = "0123456789abcdef";
+        for (int i = 0; i < 32; ++i)
+            token.push_back(hex[rd() % 16]);
+    }
+
+    // logs/ 只保留最近 10 个日志文件，防止无限累积。
+    CommonUtil::pruneLogFiles("logs", 10);
 
     std::string ts = CommonUtil::get_timestamp();
     loguru::add_file(("logs/web_" + ts + ".log").c_str(), loguru::Append, loguru::Verbosity_MAX);
@@ -485,13 +82,15 @@ int main(int argc, char* argv[])
     AnalysisSession session(TsharkCommand::resolveTsharkPath(), "data");
     if (!TsharkCommand::tsharkAvailable(session.tsharkPath()))
     {
-        LOG_F(WARNING, "未检测到 tshark（%s）。抓包/解析类接口会失败，请安装 Wireshark：%s",
+        LOG_F(INFO, "未检测到 tshark（%s）：已启用内置解析引擎（libpcap + 自研协议解析），"
+                    "离线分析/实时抓包/详情树/常用过滤可用；安装 Wireshark 可解锁完整协议支持：%s",
               session.tsharkPath().c_str(), TsharkCommand::wiresharkDownloadUrl().c_str());
     }
 
-    WebState        state(session);
     httplib::Server svr;
-    registerRoutes(svr, state);
+    // 请求体上限：httplib 默认 SIZE_MAX，鉴权在 body 读入之后才发生，超大 POST 可在授权前 OOM。
+    svr.set_payload_max_length(16u * 1024 * 1024);
+    registerWebRoutes(svr, session, token);
 
     // 托管静态前端；根路径重定向到 index.html。
     std::string webRoot = resolveWebRoot();
@@ -502,7 +101,11 @@ int main(int argc, char* argv[])
           webRoot.c_str());
     std::printf("EasyTshark Web 服务已启动：http://%s:%d\n", host.c_str(), port);
     std::printf("（默认只绑本机回环；远程访问请用 SSH 端口转发，勿裸绑 0.0.0.0）\n");
+    std::printf("访问令牌（Token）：%s\n", token.c_str());
+    std::printf("浏览器首次打开页面时请输入该令牌（令牌会保存在浏览器本地）。\n");
     std::fflush(stdout);
+
+    LOG_F(INFO, "访问令牌: %s", token.c_str());
 
     if (!svr.listen(host.c_str(), port))
     {

--- a/src/xdb_search.cc
+++ b/src/xdb_search.cc
@@ -119,8 +119,11 @@ xdb_search_t::xdb_search_t(const std::string &file_name) {
     vector_index = NULL;
     content      = NULL;
 
-    if (db == NULL)
-        log_exit("can't open " + file_name);
+    if (db == NULL) {
+        // 不 exit(-1)：IP 地理库缺失时整个程序退出会拖垮抓包/分析主流程。
+        // 保持 db==NULL 的失败态，调用方（IP2RegionUtil）经 is_ok() 降级为空归属地。
+        std::cout << "can't open " + file_name << std::endl;
+    }
 }
 
 void xdb_search_t::init_file() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,9 @@ set(TEST_SOURCES
     test_performance.cpp
     test_offline_analysis.cpp
     test_packet_parser.cpp
+    test_web_api.cpp
+    test_live_capture.cpp
+    test_native_engine.cpp
 )
 
 # 下载并包含GoogleTest源码
@@ -38,6 +41,13 @@ add_subdirectory(
 
 # 添加测试可执行文件
 add_executable(unit_tests ${TEST_SOURCES})
+
+# 测试代码允许用 C++17（如结构化绑定）：仅作用于测试目标，不放宽产品代码的 C++11 约束。
+# 生产库/可执行仍是严格 -std=c++11（见顶层 CMAKE_CXX_STANDARD/EXTENSIONS）。
+set_target_properties(unit_tests PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS OFF)
 
 # 包含GoogleTest头文件
 target_include_directories(unit_tests PRIVATE

--- a/tests/test_live_capture.cpp
+++ b/tests/test_live_capture.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "LiveCapture.hpp"
+
+// 实时抓包路径的集成测试（POSIX）：用一段假 tshark 脚本替代真实 tshark。
+// 脚本忽略所有参数，直接向 stdout 打 3 行 tshark -T fields 格式的报文摘要
+// （16 个 tab 分隔字段，顺序与 TsharkCommand::tsharkFieldArgs / PacketParser 对应），
+// 然后 sleep 保持——模拟真实 tshark 抓包挂起、等停止信号收尾的行为。
+// 验证：startCapture 成功返回、回调逐包收到、字段解析正确、stopCapture 幂等收尾。
+#if !defined(_WIN32)
+
+namespace
+{
+const char* kScript = R"SCRIPT(
+#!/bin/sh
+# 假 tshark：输出 3 行 fields 摘要后保持挂起，等 SIGTERM 收尾。
+printf '1\t1787130000.123\t64\t64\t00:11:22:33:44:55\t66:77:88:99:aa:bb\t192.168.1.1\t\t192.168.1.2\t\t1234\t\t80\t\tTCP\tSYN from fake tshark\n'
+printf '2\t1787130000.223\t128\t128\t00:11:22:33:44:55\t66:77:88:99:aa:bb\t192.168.1.1\t\t192.168.1.2\t\t1234\t\t80\t\tTCP\tACK\n'
+printf '3\t1787130000.323\t96\t96\t00:11:22:33:44:55\t66:77:88:99:aa:bb\t192.168.1.1\t\t192.168.1.2\t\t\t\t53\t\tUDP\tDNS query\n'
+exec sleep 1000  # exec: sh 被替换为 sleep，pid 不变，SIGTERM 直达
+)SCRIPT";
+} // namespace
+
+class LiveCaptureFakeTsharkTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        // 生成假 tshark 脚本（每次测试独立文件，避免并发冲突）
+        scriptPath_ = "test_data/fake_tshark_live_" + std::to_string(::getpid()) + ".sh";
+        std::ofstream out(scriptPath_.c_str());
+        ASSERT_TRUE(out.good()) << "无法创建假 tshark 脚本";
+        out << kScript;
+        out.close();
+        // 可执行权限
+        ASSERT_EQ(std::system(("chmod +x " + scriptPath_).c_str()), 0);
+    }
+
+    void TearDown() override { std::remove(scriptPath_.c_str()); }
+
+    std::string scriptPath_;
+};
+
+TEST_F(LiveCaptureFakeTsharkTest, StreamsThreePacketsAndStops)
+{
+    // ip2RegionDbPath 传不存在的路径：初始化失败仅 warning，不影响抓包
+    LiveCapture capture(scriptPath_, "test_data/no_such_xdb.bin");
+
+    std::atomic<int> received{0};
+    std::string      firstSrcIp;
+    std::string      firstProto;
+    std::string      captureFile = "test_data/fake_capture.pcap";
+
+    ASSERT_TRUE(capture.startCapture("fake-adapter",
+                                     [&received, &firstSrcIp, &firstProto](
+                                         const std::shared_ptr<Packet>& p)
+                                     {
+                                         if (received.load() == 0)
+                                         {
+                                             firstSrcIp = p->src_ip;
+                                             firstProto = p->protocol;
+                                         }
+                                         received.fetch_add(1);
+                                     },
+                                     captureFile));
+
+    // 等待脚本输出 3 行被解析（回调执行）；最多等 5s
+    for (int i = 0; i < 100 && received.load() < 3; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(received.load(), 3);
+    EXPECT_EQ(firstSrcIp, "192.168.1.1");
+    EXPECT_EQ(firstProto, "TCP");
+
+    // 停止：发 SIGTERM 令脚本收尾，join 工作线程
+    EXPECT_TRUE(capture.stopCapture());
+    // 幂等：重复 stop 不崩溃、返回合理值（未在抓包）
+    capture.stopCapture();
+    EXPECT_FALSE(capture.isCapturing());
+}
+
+TEST_F(LiveCaptureFakeTsharkTest, MissingExecutableFailsFast)
+{
+    // 不存在的 tshark 路径：fork 会成功（PopenEx 返回管道），但子进程 execvp 失败后
+    // 立即 _exit(127)，读循环收到 EOF 快速收尾。验证：不崩溃、最终不再处于抓包状态。
+    LiveCapture capture("test_data/definitely_not_a_tshark_binary_xyz",
+                        "test_data/no_such_xdb.bin");
+    bool ok = capture.startCapture("fake-adapter");
+    // fork 成功即返回 true（进程已拉起）；exec 失败由线程内 EOF 收尾体现
+    EXPECT_TRUE(ok);
+    // 等待线程收尾（读循环 EOF + PcloseEx 回收），最多 5s
+    for (int i = 0; i < 100 && capture.isCapturing(); ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(capture.isCapturing());
+}
+
+#endif // !defined(_WIN32)
+
+#if defined(_WIN32)
+TEST(LiveCaptureWinTest, SkippedOnWindows)
+{
+    GTEST_SKIP() << "假 tshark 脚本测试仅支持 POSIX（Windows 需 .bat 方案，暂未实现）";
+}
+#endif

--- a/tests/test_native_engine.cpp
+++ b/tests/test_native_engine.cpp
@@ -1,0 +1,993 @@
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "NativeAnalyzer.hpp"
+#include "NativeCapture.hpp"
+#include "NativePacketParser.hpp"
+
+// 自研引擎（无 tshark 兜底）单元测试：全部用构造的字节流验证，
+// 不依赖 tshark、不依赖真实网卡，可在任何环境运行。
+
+namespace
+{
+// ---- 字节拼装工具 ----
+void pushByte(std::vector<unsigned char>& v, unsigned char b) { v.push_back(b); }
+void pushBE16(std::vector<unsigned char>& v, uint16_t x)
+{
+    v.push_back(static_cast<unsigned char>(x >> 8));
+    v.push_back(static_cast<unsigned char>(x & 0xff));
+}
+void pushBE32(std::vector<unsigned char>& v, uint32_t x)
+{
+    v.push_back(static_cast<unsigned char>(x >> 24));
+    v.push_back(static_cast<unsigned char>((x >> 16) & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 8) & 0xff));
+    v.push_back(static_cast<unsigned char>(x & 0xff));
+}
+void pushBytes(std::vector<unsigned char>& v, const std::vector<unsigned char>& src)
+{
+    v.insert(v.end(), src.begin(), src.end());
+}
+void pushHex(std::vector<unsigned char>& v, const char* hex)
+{
+    while (*hex)
+    {
+        auto nib = [](char c) -> unsigned char {
+            return (c >= '0' && c <= '9') ? static_cast<unsigned char>(c - '0')
+                                          : static_cast<unsigned char>(c - 'a' + 10);
+        };
+        v.push_back(static_cast<unsigned char>((nib(hex[0]) << 4) | nib(hex[1])));
+        hex += 2;
+    }
+}
+
+// Ethernet 头：dst(6) src(6) type(2)
+std::vector<unsigned char> ethHeader(uint16_t ethertype)
+{
+    std::vector<unsigned char> v;
+    pushHex(v, "00112233445566778899aabb");
+    pushBE16(v, ethertype);
+    return v;
+}
+
+// IPv4 头（ihl=5）：src/dst + protocol
+std::vector<unsigned char> ipv4Header(const char* src, const char* dst, uint8_t proto,
+                                      uint16_t totalLen)
+{
+    std::vector<unsigned char> v;
+    pushByte(v, 0x45);
+    pushByte(v, 0x00);
+    pushBE16(v, totalLen);
+    pushBE16(v, 0x0000); // id
+    pushBE16(v, 0x4000); // flags + frag
+    pushByte(v, 64);     // ttl
+    pushByte(v, proto);
+    pushBE16(v, 0x0000); // checksum（不校验）
+    unsigned a, b, c, d;
+    std::sscanf(src, "%u.%u.%u.%u", &a, &b, &c, &d);
+    pushByte(v, static_cast<unsigned char>(a));
+    pushByte(v, static_cast<unsigned char>(b));
+    pushByte(v, static_cast<unsigned char>(c));
+    pushByte(v, static_cast<unsigned char>(d));
+    std::sscanf(dst, "%u.%u.%u.%u", &a, &b, &c, &d);
+    pushByte(v, static_cast<unsigned char>(a));
+    pushByte(v, static_cast<unsigned char>(b));
+    pushByte(v, static_cast<unsigned char>(c));
+    pushByte(v, static_cast<unsigned char>(d));
+    return v;
+}
+
+// TCP 头（offset=5）：src/dst port + flags
+std::vector<unsigned char> tcpHeader(uint16_t srcPort, uint16_t dstPort, unsigned char flags)
+{
+    std::vector<unsigned char> v;
+    pushBE16(v, srcPort);
+    pushBE16(v, dstPort);
+    pushBE32(v, 1);     // seq
+    pushBE32(v, 0);     // ack
+    pushByte(v, 0x50);  // offset 5
+    pushByte(v, flags);
+    pushBE16(v, 64240); // win
+    pushBE16(v, 0);     // checksum
+    pushBE16(v, 0);     // urgent pointer（凑满 20 字节标准头）
+    return v;
+}
+
+// UDP 头
+std::vector<unsigned char> udpHeader(uint16_t srcPort, uint16_t dstPort, uint16_t len)
+{
+    std::vector<unsigned char> v;
+    pushBE16(v, srcPort);
+    pushBE16(v, dstPort);
+    pushBE16(v, len);
+    pushBE16(v, 0);
+    return v;
+}
+
+// 完整 TCP SYN 帧：192.168.1.10:12345 → 93.184.216.34:80
+std::vector<unsigned char> tcpSynFrame()
+{
+    auto eth = ethHeader(0x0800);
+    auto ip  = ipv4Header("192.168.1.10", "93.184.216.34", 6, 40);
+    auto tcp = tcpHeader(12345, 80, 0x02);
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, tcp);
+    return frame;
+}
+
+// 完整 DNS 查询帧：192.168.1.10:53000 → 8.8.8.8:53 查询 example.com A
+std::vector<unsigned char> dnsQueryFrame()
+{
+    auto eth = ethHeader(0x0800);
+    // DNS payload：id=0x1234 flags=0x0100 qd=1；name "example.com"；qtype A(1) qclass IN(1)
+    std::vector<unsigned char> dns;
+    pushBE16(dns, 0x1234);
+    pushBE16(dns, 0x0100);
+    pushBE16(dns, 1); // QDCOUNT
+    pushBE16(dns, 0); // ANCOUNT
+    pushBE16(dns, 0);
+    pushBE16(dns, 0);
+    pushByte(dns, 7);
+    pushHex(dns, "6578616d706c65"); // "example"
+    pushByte(dns, 3);
+    pushHex(dns, "636f6d"); // "com"
+    pushByte(dns, 0);
+    pushBE16(dns, 1); // qtype A
+    pushBE16(dns, 1); // qclass IN
+    uint16_t udpLen = static_cast<uint16_t>(8 + dns.size());
+    auto     udp    = udpHeader(53000, 53, udpLen);
+    auto     ip     = ipv4Header("192.168.1.10", "8.8.8.8", 17, static_cast<uint16_t>(20 + udpLen));
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, udp);
+    pushBytes(frame, dns);
+    return frame;
+}
+
+// ARP 请求帧
+std::vector<unsigned char> arpFrame()
+{
+    std::vector<unsigned char> frame = ethHeader(0x0806);
+    pushBE16(frame, 1);    // htype ethernet
+    pushBE16(frame, 0x0800);
+    pushByte(frame, 6);
+    pushByte(frame, 4);
+    pushBE16(frame, 1); // request
+    pushHex(frame, "001122334455"); // sha
+    pushHex(frame, "c0a80101");     // spa 192.168.1.1
+    pushHex(frame, "000000000000"); // tha
+    pushHex(frame, "c0a80164");     // tpa 192.168.1.100
+    return frame;
+}
+
+// VLAN 标签的 IPv4 帧
+std::vector<unsigned char> vlanFrame()
+{
+    auto frame = ethHeader(0x8100);
+    pushBE16(frame, 0x0064); // TCI（VID=100）
+    pushBE16(frame, 0x0800); // 内层 ethertype
+    auto ip = ipv4Header("10.0.0.1", "10.0.0.2", 6, 40);
+    pushBytes(frame, ip);
+    pushBytes(frame, tcpHeader(1000, 2000, 0x10));
+    return frame;
+}
+
+// IPv6 + TCP 帧
+std::vector<unsigned char> ipv6Frame()
+{
+    std::vector<unsigned char> frame = ethHeader(0x86dd);
+    // 固定头：version/tc/flow=0x60000000, payload len=20, next=6, hop=64
+    pushBE32(frame, 0x60000000);
+    pushBE16(frame, 20);
+    pushByte(frame, 6);
+    pushByte(frame, 64);
+    // src fe80::1, dst fe80::2
+    pushHex(frame, "fe800000000000000000000000000001");
+    pushHex(frame, "fe800000000000000000000000000002");
+    pushBytes(frame, tcpHeader(443, 5555, 0x12)); // SYN+ACK
+    return frame;
+}
+
+// 小端写 uint32（pcap 记录头用）
+void pushLe32(std::vector<unsigned char>& v, uint32_t x)
+{
+    v.push_back(static_cast<unsigned char>(x & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 8) & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 16) & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 24) & 0xff));
+}
+void pushLe16(std::vector<unsigned char>& v, uint16_t x)
+{
+    v.push_back(static_cast<unsigned char>(x & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 8) & 0xff));
+}
+
+// 经典 pcap 文件（小端）：2 包
+std::vector<unsigned char> makePcapFile(const std::vector<unsigned char>& f1,
+                                        const std::vector<unsigned char>& f2)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, 0xa1b2c3d4); // magic
+    pushLe16(v, 2);
+    pushLe16(v, 4);
+    pushLe32(v, 0); // thiszone
+    pushLe32(v, 0); // sigfigs
+    pushLe32(v, 65535);
+    pushLe32(v, 1); // LINKTYPE_ETHERNET
+    // record 1
+    pushLe32(v, 1); // ts_sec
+    pushLe32(v, 500000);
+    pushLe32(v, static_cast<uint32_t>(f1.size()));
+    pushLe32(v, static_cast<uint32_t>(f1.size()));
+    pushBytes(v, f1);
+    // record 2
+    pushLe32(v, 1);
+    pushLe32(v, 600000);
+    pushLe32(v, static_cast<uint32_t>(f2.size()));
+    pushLe32(v, static_cast<uint32_t>(f2.size()));
+    pushBytes(v, f2);
+    return v;
+}
+} // namespace
+
+// ---- NativePacketParser ----
+TEST(NativeParserTest, ParsesTcpSyn)
+{
+    auto frame = tcpSynFrame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.src_mac, "66:77:88:99:aa:bb");
+    EXPECT_EQ(p.dst_mac, "00:11:22:33:44:55");
+    EXPECT_EQ(p.src_ip, "192.168.1.10");
+    EXPECT_EQ(p.dst_ip, "93.184.216.34");
+    EXPECT_EQ(p.src_port, 12345);
+    EXPECT_EQ(p.dst_port, 80);
+    EXPECT_EQ(p.transport, "TCP");
+    EXPECT_EQ(p.protocol, "HTTP"); // 80 端口识别
+    EXPECT_NE(p.info.find("12345"), std::string::npos);
+    EXPECT_NE(p.info.find("[SYN]"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesDnsQuery)
+{
+    auto frame = dnsQueryFrame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DNS");
+    EXPECT_EQ(p.dst_port, 53);
+    EXPECT_NE(p.info.find("example.com"), std::string::npos);
+    EXPECT_NE(p.info.find("0x1234"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesArp)
+{
+    auto frame = arpFrame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "ARP");
+    EXPECT_NE(p.info.find("192.168.1.100"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesVlan)
+{
+    auto frame = vlanFrame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.src_ip, "10.0.0.1");
+    EXPECT_EQ(p.src_port, 1000);
+    EXPECT_EQ(p.transport, "TCP");
+}
+
+TEST(NativeParserTest, ParsesIpv6)
+{
+    auto frame = ipv6Frame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_NE(p.src_ip.find("fe80"), std::string::npos);
+    EXPECT_EQ(p.src_port, 443);
+    EXPECT_EQ(p.transport, "TCP");
+}
+
+TEST(NativeParserTest, RejectsTruncatedFrame)
+{
+    auto frame = tcpSynFrame();
+    Packet p;
+    // 只给 5 字节：不足以太网头
+    EXPECT_FALSE(NativePacketParser::parseFrame(frame.data(), 5, p));
+}
+
+
+TEST(NativeParserTest, ParsesNullLoopbackFrame)
+{
+    // BSD lo 接口：4 字节小端地址族（AF_INET=2）+ IPv4/TCP
+    std::vector<unsigned char> frame;
+    pushByte(frame, 0x02); pushByte(frame, 0); pushByte(frame, 0); pushByte(frame, 0);
+    pushBytes(frame, ipv4Header("127.0.0.1", "127.0.0.1", 6, 40));
+    pushBytes(frame, tcpHeader(5000, 80, 0x02));
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.src_ip, "127.0.0.1");
+    EXPECT_EQ(p.dst_port, 80);
+    EXPECT_EQ(p.transport, "TCP");
+    EXPECT_EQ(p.protocol, "HTTP");
+    // 无以太网头：MAC 应为空
+    EXPECT_TRUE(p.src_mac.empty());
+    // 显式 linkType=0（NULL）也应解析
+    Packet p2;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p2, 0));
+    EXPECT_EQ(p2.src_ip, "127.0.0.1");
+}
+
+TEST(NativeParserTest, BuildsDetailTree)
+{
+    auto frame = tcpSynFrame();
+    DetailNode root;
+    ASSERT_TRUE(NativePacketParser::buildDetailTree(frame.data(),
+                                                    static_cast<uint32_t>(frame.size()), 1, 7,
+                                                    root));
+    EXPECT_EQ(root.label, "Frame 7");
+    ASSERT_GE(root.children.size(), 3u); // Ethernet + IP + TCP
+    EXPECT_EQ(root.children[0].label, "Ethernet II");
+    EXPECT_EQ(root.children[1].label, "Internet Protocol Version 4");
+    EXPECT_EQ(root.children[2].label, "Transmission Control Protocol");
+}
+
+TEST(NativeParserTest, DisplayFilterBasics)
+{
+    auto tcpFrame = tcpSynFrame();
+    auto dnsFrame = dnsQueryFrame();
+    auto arp      = arpFrame();
+    Packet tcpP, dnsP, arpP;
+    NativePacketParser::parseFrame(tcpFrame.data(), static_cast<uint32_t>(tcpFrame.size()), tcpP);
+    NativePacketParser::parseFrame(dnsFrame.data(), static_cast<uint32_t>(dnsFrame.size()), dnsP);
+    NativePacketParser::parseFrame(arp.data(), static_cast<uint32_t>(arp.size()), arpP);
+
+    std::string err;
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("ip.src==192.168.1.10", tcpP, &err));
+    EXPECT_TRUE(err.empty());
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("tcp.port==80", tcpP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("tcp.port==12345", tcpP, &err));
+    EXPECT_FALSE(NativePacketParser::matchDisplayFilter("tcp.port==99", tcpP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("dns", dnsP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("ip.addr==8.8.8.8 && dns", dnsP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("!tcp", arpP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("arp", arpP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("arp || tcp", arpP, &err));
+    EXPECT_FALSE(NativePacketParser::matchDisplayFilter("frame.number==5", tcpP, &err));
+
+    // 非法字段：报错且返回 false
+    std::string badErr;
+    EXPECT_FALSE(NativePacketParser::matchDisplayFilter("no.such.field==1", tcpP, &badErr));
+    EXPECT_FALSE(badErr.empty());
+}
+
+// ---- NativeAnalyzer（离线 pcap 解析）----
+class NativeAnalyzerTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        auto f1 = tcpSynFrame();
+        auto f2 = dnsQueryFrame();
+        auto bytes = makePcapFile(f1, f2);
+        pcapPath_  = "test_data/native_test.pcap";
+        std::ofstream out(pcapPath_.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+        out.close();
+        f1Bytes_ = f1;
+        f2Bytes_ = f2;
+    }
+    void TearDown() override { std::remove(pcapPath_.c_str()); }
+
+    std::string pcapPath_;
+    std::vector<unsigned char> f1Bytes_, f2Bytes_;
+};
+
+TEST_F(NativeAnalyzerTest, AnalyzesPcapAndHex)
+{
+    NativeAnalyzer analyzer;
+    std::vector<std::shared_ptr<Packet>> packets;
+    ASSERT_TRUE(analyzer.analyzeFile(pcapPath_, packets));
+    ASSERT_EQ(packets.size(), 2u);
+
+    EXPECT_EQ(packets[0]->frame_number, 1);
+    EXPECT_EQ(packets[0]->src_ip, "192.168.1.10");
+    EXPECT_EQ(packets[0]->protocol, "HTTP");
+    EXPECT_EQ(packets[1]->frame_number, 2);
+    EXPECT_EQ(packets[1]->protocol, "DNS");
+    EXPECT_NEAR(packets[0]->time, 1.5, 1e-6);
+    EXPECT_NEAR(packets[1]->time, 1.6, 1e-6);
+
+    // hex：与写入的原始帧逐字节一致
+    std::vector<unsigned char> hex;
+    ASSERT_TRUE(analyzer.getPacketHexData(1, hex));
+    ASSERT_EQ(hex.size(), f1Bytes_.size());
+    EXPECT_EQ(std::memcmp(hex.data(), f1Bytes_.data(), hex.size()), 0);
+
+    std::vector<unsigned char> hex2;
+    ASSERT_TRUE(analyzer.getPacketHexData(2, hex2));
+    EXPECT_EQ(std::memcmp(hex2.data(), f2Bytes_.data(), hex2.size()), 0);
+
+    // 不存在的帧号
+    std::vector<unsigned char> empty;
+    EXPECT_FALSE(analyzer.getPacketHexData(99, empty));
+
+    // 详情树
+    DetailNode root;
+    ASSERT_TRUE(analyzer.getPacketDetailTree(1, root));
+    EXPECT_EQ(root.label, "Frame 1");
+
+    // 显示过滤：两个包 src_ip 都是 192.168.1.10
+    std::vector<uint32_t> frames;
+    ASSERT_TRUE(analyzer.getFramesByDisplayFilter("ip.addr==192.168.1.10", frames));
+    ASSERT_EQ(frames.size(), 2u);
+    EXPECT_EQ(frames[0], 1);
+    EXPECT_EQ(frames[1], 2);
+
+    std::string err;
+    std::vector<uint32_t> bad;
+    EXPECT_FALSE(analyzer.getFramesByDisplayFilter("bogus.field==1", bad, &err));
+    EXPECT_FALSE(err.empty());
+}
+
+// ---- AnalysisSession native 集成（无 tshark 时后端自动降级）----
+#include "AnalysisSession.hpp"
+
+TEST(NativeSessionIntegration, WorksWithoutTshark)
+{
+    // 传无效 tshark 路径：构造函数内 tsharkAvailable=false → 启用自研引擎
+    AnalysisSession session("/nonexistent/tshark", "test_data/ns_data");
+
+    // 用 NativeAnalyzerTest 同款 pcap（2 包）
+    auto f1 = tcpSynFrame();
+    auto f2 = dnsQueryFrame();
+    auto bytes = makePcapFile(f1, f2);
+    std::string pcapPath = "test_data/ns_load.pcap";
+    {
+        std::ofstream out(pcapPath.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+
+    ASSERT_TRUE(session.loadPcap(pcapPath));
+    EXPECT_EQ(session.packetCount(), 2u);
+
+    // hex（native reader）
+    std::vector<unsigned char> hex;
+    ASSERT_TRUE(session.getHex(1, hex));
+    EXPECT_EQ(hex.size(), f1.size());
+
+    // 详情树（自研分层）
+    DetailNode root;
+    ASSERT_TRUE(session.getDetailTree(1, root));
+    EXPECT_EQ(root.label, "Frame 1");
+
+    // 显示过滤（自研子集）
+    std::vector<std::shared_ptr<Packet>> out;
+    ASSERT_TRUE(session.queryDisplayFilter("tcp.port==80", out));
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0]->src_ip, "192.168.1.10");
+
+    // 非法表达式：自研引擎报"unsupported field"
+    std::string err;
+    EXPECT_FALSE(session.queryDisplayFilter("bogus.field==1", out, &err));
+    EXPECT_FALSE(err.empty());
+
+    // 网卡枚举（libpcap）：不崩溃即可（可能因权限为空，不做非空断言）
+    session.listAdapters();
+
+    // SQLite 条件查询（native 模式同样入库）
+    std::string jsonResult;
+    std::map<std::string, std::string> cond;
+    cond["ip_address"] = "192.168.1.*";
+    ASSERT_TRUE(session.query(cond, jsonResult));
+    EXPECT_NE(jsonResult.find("192.168.1.10"), std::string::npos);
+
+    std::remove(pcapPath.c_str());
+    // 清理 ns_data 目录
+    std::remove("test_data/ns_data/pcaps/capture_1.pcap");
+}
+
+// savePcapAs：另存到尚不存在的多层目录时应自动创建父目录（mkdir -p 语义）。
+TEST(NativeSessionSaveAs, CreatesNestedDirs)
+{
+    AnalysisSession session("/nonexistent/tshark", "test_data/save_data");
+
+    auto        bytes    = makePcapFile(tcpSynFrame(), dnsQueryFrame());
+    std::string pcapPath = "test_data/save_src.pcap";
+    {
+        std::ofstream out(pcapPath.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+    ASSERT_TRUE(session.loadPcap(pcapPath));
+
+    // 目标目录 test_data/save_out/a/b 事先不存在——savePcapAs 应自动补齐后再拷贝。
+    std::string dest = "test_data/save_out/a/b/copy.pcap";
+    ASSERT_TRUE(session.savePcapAs(dest));
+
+    std::ifstream check(dest.c_str(), std::ios::binary);
+    ASSERT_TRUE(check.good());
+    check.seekg(0, std::ios::end);
+    EXPECT_EQ(static_cast<size_t>(check.tellg()), bytes.size()); // 内容完整拷贝
+    check.close();
+
+    // 目标即源：短路视为成功，不报错。
+    EXPECT_TRUE(session.savePcapAs(session.pcapPath()));
+
+    // 清理
+    std::remove(dest.c_str());
+    std::remove("test_data/save_out/a/b");
+    std::remove("test_data/save_out/a");
+    std::remove("test_data/save_out");
+    std::remove(pcapPath.c_str());
+    std::remove("test_data/save_data/pcaps/capture_1.pcap");
+}
+
+// ---- 应用层协议测试 helper ----
+// 完整以太网帧：eth + ipv4 + tcp + payload
+std::vector<unsigned char> tcpPayloadFrame(const char* srcIp, const char* dstIp,
+                                           uint16_t srcPort, uint16_t dstPort,
+                                           const std::vector<unsigned char>& payload,
+                                           bool fragMF = false)
+{
+    uint16_t total = static_cast<uint16_t>(20 + 20 + payload.size());
+    auto     eth   = ethHeader(0x0800);
+    auto     ip    = ipv4Header(srcIp, dstIp, 6, total);
+    if (fragMF)
+        ip[6] = 0x20; // flags MF（大端字段：flags 在字节 6-7 高 4 位）
+    auto     tcp   = tcpHeader(srcPort, dstPort, 0x18); // PSH+ACK
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, tcp);
+    pushBytes(frame, payload);
+    return frame;
+}
+
+// 以太网 + IPv4 + UDP + payload
+std::vector<unsigned char> udpPayloadFrame(const char* srcIp, const char* dstIp,
+                                           uint16_t srcPort, uint16_t dstPort,
+                                           const std::vector<unsigned char>& payload)
+{
+    uint16_t udpLen = static_cast<uint16_t>(8 + payload.size());
+    auto     eth    = ethHeader(0x0800);
+    auto     ip     = ipv4Header(srcIp, dstIp, 17, static_cast<uint16_t>(20 + udpLen));
+    auto     udp    = udpHeader(srcPort, dstPort, udpLen);
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, udp);
+    pushBytes(frame, payload);
+    return frame;
+}
+
+std::vector<unsigned char> strVec(const std::string& s)
+{
+    return std::vector<unsigned char>(s.begin(), s.end());
+}
+
+// ---- HTTP ----
+TEST(NativeParserTest, ParsesHttpRequest)
+{
+    auto payload = strVec("GET /index.html HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl\r\n\r\n");
+    auto frame   = tcpPayloadFrame("192.168.1.10", "93.184.216.34", 5000, 80, payload);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "HTTP");
+    EXPECT_NE(p.info.find("GET /index.html"), std::string::npos);
+    EXPECT_NE(p.info.find("example.com"), std::string::npos);
+
+    // 完整详情树含 HTTP 层
+    DetailNode root;
+    ASSERT_TRUE(NativePacketParser::buildDetailTree(frame.data(),
+                                                    static_cast<uint32_t>(frame.size()), 1, 1,
+                                                    root));
+    bool hasHttp = false;
+    for (const auto& c : root.children)
+        if (c.label == "Hypertext Transfer Protocol") hasHttp = true;
+    EXPECT_TRUE(hasHttp);
+}
+
+TEST(NativeParserTest, ParsesHttpResponse)
+{
+    auto payload = strVec("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 10\r\n\r\n");
+    auto frame   = tcpPayloadFrame("93.184.216.34", "192.168.1.10", 80, 5000, payload);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "HTTP");
+    EXPECT_NE(p.info.find("200"), std::string::npos);
+    EXPECT_NE(p.info.find("OK"), std::string::npos);
+}
+
+// ---- TLS ClientHello + SNI ----
+TEST(NativeParserTest, ParsesTlsClientHelloWithSni)
+{
+    std::vector<unsigned char> tls;
+    // record: handshake(0x16) TLS1.2(0303) len
+    pushByte(tls, 0x16); pushByte(tls, 0x03); pushByte(tls, 0x03);
+    pushBE16(tls, 64); // record payload = handshake 4 + body 60
+    // handshake: ClientHello(1) + length(3 字节)
+    pushByte(tls, 0x01);
+    pushByte(tls, 0x00); pushByte(tls, 0x00); pushByte(tls, 0x3c);
+    // body: version 0303 + random 32 + sessionId len 0
+    pushByte(tls, 0x03); pushByte(tls, 0x03);
+    for (int i = 0; i < 32; ++i) pushByte(tls, 0x11);
+    pushByte(tls, 0x00);
+    // cipher suites: len 2, 0xc02f
+    pushBE16(tls, 2); pushBE16(tls, 0xc02f);
+    // compression: len 0
+    pushByte(tls, 0x00);
+    // extensions total: 20
+    pushBE16(tls, 20);
+    // SNI ext: type 0, len 16: listLen 14, nameType 0, nameLen 11, "example.com"
+    pushBE16(tls, 0); pushBE16(tls, 16);
+    pushBE16(tls, 14); pushByte(tls, 0); pushBE16(tls, 11);
+    pushHex(tls, "6578616d706c652e636f6d"); // example.com
+
+    auto frame = tcpPayloadFrame("192.168.1.10", "93.184.216.34", 5000, 443, tls);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "TLS");
+    EXPECT_NE(p.info.find("Client Hello"), std::string::npos);
+    EXPECT_NE(p.info.find("example.com"), std::string::npos);
+    EXPECT_NE(p.info.find("TLS 1.2"), std::string::npos);
+}
+
+// ---- DNS 响应 ----
+TEST(NativeParserTest, ParsesDnsResponse)
+{
+    std::vector<unsigned char> dns;
+    pushBE16(dns, 0xabcd); // id
+    pushBE16(dns, 0x8180); // response + RD + RA
+    pushBE16(dns, 1); // QDCOUNT
+    pushBE16(dns, 1); // ANCOUNT
+    pushBE16(dns, 0);
+    pushBE16(dns, 0);
+    // question: example.com A IN
+    pushByte(dns, 7); pushHex(dns, "6578616d706c65");
+    pushByte(dns, 3); pushHex(dns, "636f6d");
+    pushByte(dns, 0);
+    pushBE16(dns, 1); pushBE16(dns, 1);
+    // answer: name ptr 0xc00c, A, class IN, ttl 300, rdlen 4, 93.184.216.34
+    pushHex(dns, "c00c");
+    pushBE16(dns, 1); pushBE16(dns, 1); pushBE32(dns, 300); pushBE16(dns, 4);
+    pushHex(dns, "5db8d822");
+
+    auto frame = udpPayloadFrame("8.8.8.8", "192.168.1.10", 53, 53000, dns);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DNS");
+    EXPECT_NE(p.info.find("query response"), std::string::npos);
+    EXPECT_NE(p.info.find("A 93.184.216.34"), std::string::npos);
+}
+
+// ---- DHCP Discover ----
+
+TEST(NativeParserTest, ParsesDnsResponseMultipleAnswers)
+{
+    std::vector<unsigned char> dns;
+    pushBE16(dns, 0x1234);
+    pushBE16(dns, 0x8180);
+    pushBE16(dns, 1); // QD
+    pushBE16(dns, 2); // AN = 2 条
+    pushBE16(dns, 0); pushBE16(dns, 0);
+    // question: example.com A
+    pushByte(dns, 7); pushHex(dns, "6578616d706c65");
+    pushByte(dns, 3); pushHex(dns, "636f6d");
+    pushByte(dns, 0); pushBE16(dns, 1); pushBE16(dns, 1);
+    // answer1: A 93.184.216.34
+    pushHex(dns, "c00c"); pushBE16(dns, 1); pushBE16(dns, 1);
+    pushBE32(dns, 300); pushBE16(dns, 4); pushHex(dns, "5db8d822");
+    // answer2: AAAA 2606:...
+    pushHex(dns, "c00c"); pushBE16(dns, 28); pushBE16(dns, 1);
+    pushBE32(dns, 300); pushBE16(dns, 16); pushHex(dns, "26060000000000000000000000000064");
+
+    uint16_t udpLen = static_cast<uint16_t>(8 + dns.size());
+    auto     eth    = ethHeader(0x0800);
+    auto     ip     = ipv4Header("8.8.8.8", "192.168.1.10", 17, static_cast<uint16_t>(20 + udpLen));
+    auto     udp    = udpHeader(53, 53000, udpLen);
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, udp);
+    pushBytes(frame, dns);
+
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DNS");
+    EXPECT_NE(p.info.find("A 93.184.216.34"), std::string::npos);
+    // 第二条 AAAA 也应在摘要里
+    EXPECT_NE(p.info.find("AAAA 2606"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesDhcpDiscover)
+{
+    std::vector<unsigned char> dhcp;
+    pushByte(dhcp, 0x01); // op request
+    pushByte(dhcp, 0x01); // htype
+    pushByte(dhcp, 0x06); // hlen
+    pushByte(dhcp, 0x00); // hops
+    pushBE32(dhcp, 0x12345678); // xid
+    pushBE16(dhcp, 0); pushBE16(dhcp, 0); // secs flags
+    for (int i = 0; i < 4; ++i) pushBE32(dhcp, 0); // ciaddr yiaddr siaddr giaddr
+    for (int i = 0; i < 16; ++i) pushByte(dhcp, 0xaa); // chaddr
+    for (int i = 0; i < 64; ++i) pushByte(dhcp, 0);    // sname
+    for (int i = 0; i < 128; ++i) pushByte(dhcp, 0);   // file
+    pushHex(dhcp, "63825363"); // magic cookie
+    pushByte(dhcp, 53); pushByte(dhcp, 1); pushByte(dhcp, 1); // option 53 = Discover
+    pushByte(dhcp, 50); pushByte(dhcp, 4); pushHex(dhcp, "c0a80164"); // option 50 requested IP
+    pushByte(dhcp, 255); // end
+
+    auto frame = udpPayloadFrame("0.0.0.0", "255.255.255.255", 68, 67, dhcp);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DHCP");
+    EXPECT_NE(p.info.find("Discover"), std::string::npos);
+}
+
+// ---- ICMPv6 邻居请求 ----
+TEST(NativeParserTest, ParsesIcmpv6NeighborSolicitation)
+{
+    std::vector<unsigned char> frame = ethHeader(0x86dd);
+    pushBE32(frame, 0x60000000);
+    pushBE16(frame, 32); // payload len = icmpv6 8 + target 16 = 24? 用 24
+    // 修正：payload 是 ICMPv6 头 4 + target 16 = 20，但按 32 构造只影响 len 字段，不校验
+    pushByte(frame, 58); // next header ICMPv6
+    pushByte(frame, 64);
+    pushHex(frame, "fe800000000000000000000000000001");
+    pushHex(frame, "fe800000000000000000000000000002");
+    // ICMPv6: type 135 (NS) code 0
+    pushByte(frame, 135); pushByte(frame, 0);
+    pushBE16(frame, 0); // checksum（不校验）
+    pushHex(frame, "0000000000000000"); // reserved
+    pushHex(frame, "fe8000000000000000000000000000aa"); // target
+
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "ICMPv6");
+    EXPECT_NE(p.info.find("Neighbor solicitation"), std::string::npos);
+}
+
+// ---- IP 分片 ----
+TEST(NativeParserTest, MarksIpFragment)
+{
+    auto payload = strVec("fragment payload");
+    auto frame   = tcpPayloadFrame("192.168.1.10", "93.184.216.34", 5000, 80, payload, true);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "HTTP");
+    // 分片标记体现在详情树（Fragment 行）
+    DetailNode root;
+    ASSERT_TRUE(NativePacketParser::buildDetailTree(frame.data(),
+                                                    static_cast<uint32_t>(frame.size()), 1, 1,
+                                                    root));
+    bool hasFrag = false;
+    for (const auto& layer : root.children)
+        if (layer.label.find("Internet Protocol") != std::string::npos)
+            for (const auto& f : layer.children)
+                if (f.label == "Fragment") hasFrag = true;
+    EXPECT_TRUE(hasFrag);
+}
+
+// ---- 经典 pcap 大端格式 ----
+// 与 makePcapFile 同布局，但 magic 与所有头字段按大端写入（magic 0xa1b2c3d4 在盘上即
+// a1 b2 c3 d4）。验证 NativeAnalyzer 的大端分支与小端分支解析结果一致。
+std::vector<unsigned char> makePcapFileBE(const std::vector<unsigned char>& f1,
+                                          const std::vector<unsigned char>& f2)
+{
+    std::vector<unsigned char> v;
+    pushBE32(v, 0xa1b2c3d4); // magic（大端在盘上为 a1 b2 c3 d4）
+    pushBE16(v, 2);
+    pushBE16(v, 4);
+    pushBE32(v, 0);
+    pushBE32(v, 0);
+    pushBE32(v, 65535);
+    pushBE32(v, 1); // LINKTYPE_ETHERNET
+    // record 1：ts 1.5s（sec=1, usec=500000）
+    pushBE32(v, 1);
+    pushBE32(v, 500000);
+    pushBE32(v, static_cast<uint32_t>(f1.size()));
+    pushBE32(v, static_cast<uint32_t>(f1.size()));
+    pushBytes(v, f1);
+    // record 2：ts 1.6s
+    pushBE32(v, 1);
+    pushBE32(v, 600000);
+    pushBE32(v, static_cast<uint32_t>(f2.size()));
+    pushBE32(v, static_cast<uint32_t>(f2.size()));
+    pushBytes(v, f2);
+    return v;
+}
+
+TEST(NativeAnalyzerBE, ParsesBigEndianPcap)
+{
+    auto f1    = tcpSynFrame();
+    auto f2    = dnsQueryFrame();
+    auto bytes = makePcapFileBE(f1, f2);
+
+    std::string path = "test_data/native_be.pcap";
+    {
+        std::ofstream out(path.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+
+    NativeAnalyzer analyzer;
+    std::vector<std::shared_ptr<Packet>> packets;
+    ASSERT_TRUE(analyzer.analyzeFile(path, packets));
+    ASSERT_EQ(packets.size(), 2u);
+    EXPECT_EQ(packets[0]->src_ip, "192.168.1.10");
+    EXPECT_EQ(packets[0]->protocol, "HTTP");
+    EXPECT_EQ(packets[1]->protocol, "DNS");
+    EXPECT_NEAR(packets[0]->time, 1.5, 1e-6);
+    EXPECT_NEAR(packets[1]->time, 1.6, 1e-6);
+
+    // hex 与写入帧逐字节一致（大端读记录头不应影响数据区）
+    std::vector<unsigned char> hex;
+    ASSERT_TRUE(analyzer.getPacketHexData(1, hex));
+    ASSERT_EQ(hex.size(), f1.size());
+    EXPECT_EQ(std::memcmp(hex.data(), f1.data(), hex.size()), 0);
+
+    std::remove(path.c_str());
+}
+
+// ---- pcapng（SHB + IDB[if_tsresol] + EPB）----
+// 构造一个最小 pcapng：接口时间戳分辨率设为毫秒（if_tsresol=3 → 除数 1e3），
+// EPB 时间戳 tick=1500 → 期望解析出的 time = 1.5s。验证 IDB 选项解析 + EPB 帧解析。
+std::vector<unsigned char> makePcapNgFile(const std::vector<unsigned char>& frame)
+{
+    std::vector<unsigned char> v;
+
+    // ---- SHB ----
+    pushLe32(v, 0x0A0D0D0A); // block type
+    pushLe32(v, 28);         // total length
+    pushLe32(v, 0x1A2B3C4D); // byte-order magic（小端）
+    pushLe16(v, 1);          // major
+    pushLe16(v, 0);          // minor
+    pushLe32(v, 0xffffffff); // section length low（-1 = 未知）
+    pushLe32(v, 0xffffffff); // section length high
+    pushLe32(v, 28);         // total length（尾部重复）
+
+    // ---- IDB（带 if_tsresol=3）----
+    // body: linktype(2) reserved(2) snaplen(4) + opt(if_tsresol) 8 + opt_endofopt 4 = 20
+    // block = 8(头) + 20 + 4(尾) = 32
+    pushLe32(v, 0x00000001); // block type IDB
+    pushLe32(v, 32);         // total length
+    pushLe16(v, 1);          // linktype = Ethernet
+    pushLe16(v, 0);          // reserved
+    pushLe32(v, 65535);      // snaplen
+    // option if_tsresol：code=9 len=1 value=3（毫秒），补齐到 4 字节
+    pushLe16(v, 9);
+    pushLe16(v, 1);
+    pushByte(v, 3);
+    pushByte(v, 0); pushByte(v, 0); pushByte(v, 0); // padding
+    // opt_endofopt
+    pushLe16(v, 0);
+    pushLe16(v, 0);
+    pushLe32(v, 32); // total length（尾部重复）
+
+    // ---- EPB ----
+    // body: interface(4) tsHigh(4) tsLow(4) capLen(4) origLen(4) = 20 + data + pad
+    uint32_t capLen = static_cast<uint32_t>(frame.size());
+    uint32_t pad    = (4u - (capLen % 4u)) % 4u;
+    uint32_t total  = 8u + 20u + capLen + pad + 4u;
+    pushLe32(v, 0x00000006); // block type EPB
+    pushLe32(v, total);
+    pushLe32(v, 0);    // interface id 0
+    pushLe32(v, 0);    // ts high
+    pushLe32(v, 1500); // ts low：tick=1500，除数 1e3 → 1.5s
+    pushLe32(v, capLen);
+    pushLe32(v, capLen); // orig len
+    pushBytes(v, frame);
+    for (uint32_t i = 0; i < pad; ++i)
+        pushByte(v, 0);
+    pushLe32(v, total); // total length（尾部重复）
+
+    return v;
+}
+
+TEST(NativeAnalyzerNg, ParsesPcapngWithTsResol)
+{
+    auto frame = tcpSynFrame();
+    auto bytes = makePcapNgFile(frame);
+
+    std::string path = "test_data/native_ng.pcapng";
+    {
+        std::ofstream out(path.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+
+    NativeAnalyzer analyzer;
+    std::vector<std::shared_ptr<Packet>> packets;
+    ASSERT_TRUE(analyzer.analyzeFile(path, packets));
+    ASSERT_EQ(packets.size(), 1u);
+    EXPECT_EQ(packets[0]->src_ip, "192.168.1.10");
+    EXPECT_EQ(packets[0]->dst_port, 80);
+    EXPECT_EQ(packets[0]->protocol, "HTTP");
+    // if_tsresol=3（毫秒）× tick 1500 → 1.5s；若分辨率解析错误会退化为 1e6（=0.0015s）。
+    EXPECT_NEAR(packets[0]->time, 1.5, 1e-6);
+
+    std::remove(path.c_str());
+}
+
+// ---- Linux SLL / SLL2（tcpdump -i any）----
+// SLL（linktype 113）：pkttype(2) arphrd(2) lladdrlen(2) lladdr(8) protocol(2) 共 16 字节，
+// 随后是网络层。这里 protocol=0x0800（IPv4）+ IPv4/TCP。
+std::vector<unsigned char> sllFrame()
+{
+    std::vector<unsigned char> frame;
+    pushBE16(frame, 0);      // pkttype
+    pushBE16(frame, 1);      // arphrd = Ethernet
+    pushBE16(frame, 6);      // lladdrlen
+    pushHex(frame, "001122334455"); // lladdr（8 字节，取前 6 + 2 字节补零）
+    pushBE16(frame, 0);
+    pushBE16(frame, 0x0800); // protocol
+    pushBytes(frame, ipv4Header("10.1.1.1", "10.1.1.2", 6, 40));
+    pushBytes(frame, tcpHeader(4444, 80, 0x02));
+    return frame;
+}
+
+// SLL2（linktype 276）：protocol(2) reserved(2) ifindex(4) arphrd(2) pkttype(1) lladdrlen(1)
+// lladdr(8) 共 20 字节，protocol 在最前。
+std::vector<unsigned char> sll2Frame()
+{
+    std::vector<unsigned char> frame;
+    pushBE16(frame, 0x0800); // protocol
+    pushBE16(frame, 0);      // reserved
+    pushBE32(frame, 2);      // ifindex
+    pushBE16(frame, 1);      // arphrd
+    pushByte(frame, 0);      // pkttype
+    pushByte(frame, 6);      // lladdrlen
+    pushHex(frame, "0011223344550000"); // lladdr（8 字节）
+    pushBytes(frame, ipv4Header("10.2.2.1", "10.2.2.2", 17, 28));
+    pushBytes(frame, udpHeader(6000, 53, 8));
+    return frame;
+}
+
+TEST(NativeParserTest, ParsesSll)
+{
+    auto   frame = sllFrame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 113));
+    EXPECT_EQ(p.src_ip, "10.1.1.1");
+    EXPECT_EQ(p.dst_ip, "10.1.1.2");
+    EXPECT_EQ(p.dst_port, 80);
+    EXPECT_EQ(p.transport, "TCP");
+}
+
+TEST(NativeParserTest, ParsesSll2)
+{
+    auto   frame = sll2Frame();
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 276));
+    EXPECT_EQ(p.src_ip, "10.2.2.1");
+    EXPECT_EQ(p.dst_ip, "10.2.2.2");
+    EXPECT_EQ(p.dst_port, 53);
+    EXPECT_EQ(p.transport, "UDP");
+}

--- a/tests/test_web_api.cpp
+++ b/tests/test_web_api.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+#include "httplib/httplib.h"
+#include "AnalysisSession.hpp"
+#include "web/WebServer.hpp"
+
+// Web 路由层的 in-process 集成测试：
+// 与生产入口（main_web.cpp）共用同一份 registerWebRoutes 路由逻辑，在后台线程
+// listen 一个固定端口，用 httplib::Client 发真实 HTTP 请求验证：
+//   - 令牌鉴权（无 token / 错 token → 401，对 token → 200）
+//   - Origin 校验（不匹配 → 403）
+//   - /api/load 路径白名单（白名单外 → 403）
+// 不依赖真实 tshark：AnalysisSession 构造即可，抓包/解析类接口不在本测试范围。
+class WebServerTest : public ::testing::Test {
+protected:
+    static const int kPort = 18123; // 固定端口；本测试串行执行，单进程内无冲突
+    static const char* const kToken;
+
+    void SetUp() override {
+        server_   = std::unique_ptr<httplib::Server>(new httplib::Server());
+        session_  = std::unique_ptr<AnalysisSession>(new AnalysisSession("", "data"));
+        registerWebRoutes(*server_, *session_, kToken);
+
+        std::atomic<bool> started{false};
+        listenThread_ = std::thread([this, &started]() {
+            started.store(true);
+            server_->listen("127.0.0.1", kPort);
+        });
+        while (!started.load())
+            std::this_thread::yield();
+        // 等 listen 真正就绪（bind 完成）再发请求
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+
+    void TearDown() override {
+        server_->stop();
+        if (listenThread_.joinable())
+            listenThread_.join();
+    }
+
+    std::pair<int, std::string> get(const std::string& path, const std::string& token,
+                                    const std::string& origin = "")
+    {
+        httplib::Client cli("127.0.0.1", kPort);
+        httplib::Headers h;
+        if (!token.empty())
+            h.emplace("X-Auth-Token", token);
+        if (!origin.empty())
+            h.emplace("Origin", origin);
+        auto res = cli.Get(path, h);
+        if (!res)
+            return {0, ""};
+        return {res->status, res->body};
+    }
+
+    std::unique_ptr<httplib::Server> server_;
+    std::unique_ptr<AnalysisSession> session_;
+    std::thread listenThread_;
+};
+
+const char* const WebServerTest::kToken = "test-token-abc";
+
+TEST_F(WebServerTest, RequiresToken)
+{
+    auto [noToken, bodyNo] = get("/api/status", "");
+    EXPECT_EQ(noToken, 401);
+
+    auto [wrongToken, bodyWrong] = get("/api/status", "wrong");
+    EXPECT_EQ(wrongToken, 401);
+
+    auto [ok, bodyOk] = get("/api/status", kToken);
+    EXPECT_EQ(ok, 200);
+    EXPECT_NE(bodyOk.find("\"count\""), std::string::npos);
+}
+
+TEST_F(WebServerTest, RejectsForeignOrigin)
+{
+    auto [status, body] = get("/api/status", kToken, "http://evil.example.com");
+    EXPECT_EQ(status, 403);
+}
+
+TEST_F(WebServerTest, AcceptsMatchingOrigin)
+{
+    auto [status, body] = get("/api/status", kToken, "http://127.0.0.1:18123");
+    EXPECT_EQ(status, 200);
+}
+
+TEST_F(WebServerTest, LoadPathWhitelist)
+{
+    httplib::Client cli("127.0.0.1", kPort);
+
+    // 白名单外路径（/etc/hosts）→ 403
+    auto res1 = cli.Post("/api/load", {{ "X-Auth-Token", kToken }},
+                         R"({"path":"/etc/hosts"})", "application/json");
+    EXPECT_EQ(res1->status, 403);
+
+    // 白名单内（data/ 下）路径不存在 → 解析失败（非 403）
+    auto res2 = cli.Post("/api/load", {{ "X-Auth-Token", kToken }},
+                         R"({"path":"data/does_not_exist.pcap"})", "application/json");
+    EXPECT_NE(res2->status, 403);
+    EXPECT_NE(res2->status, 401);
+}
+
+TEST_F(WebServerTest, PacketsPagingShape)
+{
+    httplib::Client cli("127.0.0.1", kPort);
+
+    // 未载入任何文件：分页返回空数组、total 0，且不 500
+    auto res = cli.Get("/api/packets?page=0&pageSize=10",
+                       {{"X-Auth-Token", kToken}});
+    EXPECT_EQ(res->status, 200);
+    EXPECT_NE(res->body.find("\"total\":0"), std::string::npos);
+    EXPECT_NE(res->body.find("\"packets\":[]"), std::string::npos);
+
+    // 无 token 的分页请求 → 401
+    auto resNoTok = cli.Get("/api/packets?page=0&pageSize=10");
+    EXPECT_EQ(resNoTok->status, 401);
+}

--- a/third_party/ip2region/xdb_search.h
+++ b/third_party/ip2region/xdb_search.h
@@ -9,6 +9,9 @@ public:
     xdb_search_t(const std::string& file_name);
     ~xdb_search_t();
 
+    // 打开失败时为 false（构造不再 exit 杀进程），调用方据此降级（如归属地留空）。
+    bool is_ok() const { return db != NULL; }
+
     void init_file();
     void init_vector_index();
     void init_content();

--- a/web/app.js
+++ b/web/app.js
@@ -4,8 +4,10 @@
 
 // ---------- 全局状态 ----------
 const state = {
-    all: [],            // 当前基础报文集（快照 或 显示过滤结果）
-    filtered: null,     // 显示过滤命中的子集；null 表示未过滤
+    all: [],            // 当前基础报文（离线=当前分页；实时=已累积的全部实时包）
+    total: 0,           // 离线全量报文总数（分页模式由服务端返回）
+    full: null,         // 惰性拉取的全量报文集（统计/会话聚合用；离线非直播时首次进入相关 Tab 才拉）
+    filtered: null,     // 显示过滤命中的子集；null 表示未过滤（前端分页，命中集全量在内存）
     protoCategory: 0,   // 0全部 1ARP 2ICMP 3ICMPv6
     page: 0,
     pageSize: 100,
@@ -16,20 +18,45 @@ const state = {
 };
 
 // ---------- API 助手 ----------
+// 访问令牌：存 localStorage，首次访问时从输入框获取（见 index.html 顶部令牌条）。
+let authToken = localStorage.getItem('easytshark_token') || '';
+function apiHeaders(extra) {
+    const h = Object.assign({}, extra);
+    if (authToken) h['X-Auth-Token'] = authToken;
+    return h;
+}
+// 401 时提示重新输入令牌（token 可能被服务端重置）
+async function handleAuthError(r, data) {
+    if (r.status === 401) {
+        authToken = '';
+        localStorage.removeItem('easytshark_token');
+        $('tokenInput').value = '';
+        $('tokenBar').style.display = 'flex';
+        setStatus('令牌无效或已过期，请重新输入');
+        return true;
+    }
+    return false;
+}
 async function getJSON(url) {
-    const r = await fetch(url);
+    const r = await fetch(url, { headers: apiHeaders() });
     const data = await r.json().catch(() => ({ error: '响应不是合法 JSON' }));
-    if (!r.ok || data.error) throw new Error(data.error || ('HTTP ' + r.status));
+    if (!r.ok || data.error) {
+        if (!(await handleAuthError(r, data))) throw new Error(data.error || ('HTTP ' + r.status));
+        throw new Error('未授权');
+    }
     return data;
 }
 async function postJSON(url, body) {
     const r = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: apiHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(body || {}),
     });
     const data = await r.json().catch(() => ({ error: '响应不是合法 JSON' }));
-    if (!r.ok || data.error) throw new Error(data.error || ('HTTP ' + r.status));
+    if (!r.ok || data.error) {
+        if (!(await handleAuthError(r, data))) throw new Error(data.error || ('HTTP ' + r.status));
+        throw new Error('未授权');
+    }
     return data;
 }
 const $ = (id) => document.getElementById(id);
@@ -82,25 +109,64 @@ function escapeHtml(s) {
 function currentBase() { return state.filtered !== null ? state.filtered : state.all; }
 function currentView() { return currentBase().filter((p) => matchesCategory(p, state.protoCategory)); }
 
+// 离线分页拉取：从服务端取第 p 页（pageSize 条）作为当前报文页。
+async function loadPage(p) {
+    const ps = state.pageSize;
+    const data = await getJSON(`/api/packets?page=${p}&pageSize=${ps}`);
+    state.all = data.packets || [];
+    state.total = data.total || 0;
+    state.page = data.page || 0;
+    renderPackets();
+}
+
+// 惰性拉取全量（统计/会话聚合用）：实时抓包期间用 state.all 累积值即可。
+async function ensureFull() {
+    if (state.full !== null || state.live.active) return;
+    try {
+        const data = await getJSON('/api/packets');
+        state.full = data.packets || [];
+        state.totalBytes = state.full.reduce((s, p) => s + (p.len || 0), 0);
+        renderSessions();
+        renderStats();
+        updateStatusBar();
+    } catch (e) { /* 忽略：下次进入 Tab 重试 */ }
+}
+
 function renderPackets() {
-    const view = currentView();
-    const totalPages = Math.max(1, Math.ceil(view.length / state.pageSize));
-    if (state.page >= totalPages) state.page = totalPages - 1;
-    if (state.page < 0) state.page = 0;
-
-    const begin = state.live.active ? 0 : state.page * state.pageSize;
-    const end = state.live.active ? view.length : Math.min(view.length, begin + state.pageSize);
-    const rows = view.slice(begin, end).map(rowHtml).join('');
-    $('packetsBody').innerHTML = rows;
-
-    $('packetsCount').textContent = `共 ${view.length} 条` + (state.filtered !== null ? '（已过滤）' : '');
-    $('pageInfo').textContent = `第 ${state.page + 1} / ${totalPages} 页`;
-    $('pager').style.display = state.live.active ? 'none' : 'flex';
-
-    if (state.live.active && $('autoScroll').checked) {
-        const sc = document.querySelector('#tab-packets .table-scroll');
-        sc.scrollTop = sc.scrollHeight;
+    const base = currentBase();
+    if (state.filtered !== null) {
+        // 过滤命中集在前端内存中分页
+        const view = base.filter((p) => matchesCategory(p, state.protoCategory));
+        const totalPages = Math.max(1, Math.ceil(view.length / state.pageSize));
+        if (state.page >= totalPages) state.page = totalPages - 1;
+        if (state.page < 0) state.page = 0;
+        const begin = state.page * state.pageSize;
+        const end = Math.min(view.length, begin + state.pageSize);
+        const rows = view.slice(begin, end).map(rowHtml).join('');
+        $('packetsBody').innerHTML = rows;
+        $('packetsCount').textContent = `共 ${view.length} 条（已过滤）`;
+        $('pageInfo').textContent = `第 ${state.page + 1} / ${totalPages} 页`;
+        $('pager').style.display = state.live.active ? 'none' : 'flex';
+        return;
     }
+
+    // 离线：state.all 即当前页（服务端已切片）；实时：state.all 为已累积全部
+    const rows = base.map(rowHtml).join('');
+    $('packetsBody').innerHTML = rows;
+    if (state.live.active) {
+        $('packetsCount').textContent = `共 ${base.length} 条`;
+        $('pager').style.display = 'none';
+        if ($('autoScroll').checked) {
+            const sc = document.querySelector('#tab-packets .table-scroll');
+            sc.scrollTop = sc.scrollHeight;
+        }
+        return;
+    }
+    const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+    if (state.page >= totalPages) state.page = totalPages - 1;
+    $('packetsCount').textContent = `共 ${state.total} 条`;
+    $('pageInfo').textContent = `第 ${state.page + 1} / ${totalPages} 页`;
+    $('pager').style.display = 'flex';
 }
 function endpoint(ip, mac) { return ip || mac || ''; }
 function rowHtml(p) {
@@ -199,12 +265,14 @@ function detailNode(node) {
 
 // ---------- 数据刷新 ----------
 async function refreshSnapshot() {
-    const data = await getJSON('/api/packets');
+    const data = await getJSON(`/api/packets?page=0&pageSize=${state.pageSize}`);
     state.all = data.packets || [];
+    state.total = data.total || 0;
+    state.full = null; // 全量缓存失效，统计/会话 Tab 下次进入时惰性重拉
     state.filtered = null;
     state.selectedFrame = null;
     state.page = 0;
-    state.totalBytes = state.all.reduce((s, p) => s + (p.len || 0), 0);
+    state.totalBytes = 0; // 由 ensureFull 拉全量后填真实值
     $('detailTree').textContent = '（选中一个报文查看详情）';
     $('hexDump').textContent = '';
     $('hexTitle').textContent = '十六进制';
@@ -214,8 +282,8 @@ async function refreshSnapshot() {
     updateStatusBar();
 }
 function updateStatusBar() {
-    const n = state.live.active ? state.all.length : (state.filtered !== null ? state.filtered.length : state.all.length);
-    $('statTotal').textContent = '数据包总数: ' + state.all.length;
+    const n = state.live.active ? state.all.length : (state.filtered !== null ? state.filtered.length : state.total);
+    $('statTotal').textContent = '数据包总数: ' + n;
     $('statBytes').textContent = '总字节数: ' + state.totalBytes;
 }
 
@@ -261,9 +329,20 @@ $('protoCategory').addEventListener('change', (e) => {
 });
 
 // ---------- 分页 ----------
-$('btnPrev').addEventListener('click', () => { state.page--; renderPackets(); });
-$('btnNext').addEventListener('click', () => { state.page++; renderPackets(); });
-$('pageSize').addEventListener('change', (e) => { state.pageSize = parseInt(e.target.value, 10); state.page = 0; renderPackets(); });
+$('btnPrev').addEventListener('click', () => {
+    if (state.filtered !== null) { state.page--; renderPackets(); return; }
+    if (state.page > 0) loadPage(state.page - 1);
+});
+$('btnNext').addEventListener('click', () => {
+    if (state.filtered !== null) { state.page++; renderPackets(); return; }
+    if ((state.page + 1) * state.pageSize < state.total) loadPage(state.page + 1);
+});
+$('pageSize').addEventListener('change', (e) => {
+    state.pageSize = parseInt(e.target.value, 10);
+    state.page = 0;
+    if (state.filtered !== null) renderPackets();
+    else loadPage(0);
+});
 
 // ---------- 结构化查询 ----------
 $('btnQuery').addEventListener('click', async () => {
@@ -303,6 +382,7 @@ $('btnStart').addEventListener('click', async () => {
     try {
         await postJSON('/api/capture/start', { adapter });
         state.all = []; state.filtered = null; state.selectedFrame = null;
+        state.total = 0; state.full = null;
         state.totalBytes = 0; state.live.active = true; state.live.since = 0;
         $('btnStart').disabled = true; $('btnStop').disabled = false;
         $('liveIndicator').style.display = '';
@@ -320,7 +400,7 @@ $('btnStop').addEventListener('click', async () => {
         $('btnStart').disabled = false; $('btnStop').disabled = true;
         $('liveIndicator').style.display = 'none';
         await refreshSnapshot();
-        setStatus(`抓包完成，共 ${state.all.length} 个数据包`);
+        setStatus(`抓包完成，共 ${state.total} 个数据包`);
     } catch (e) { setStatus('停止失败：' + e.message); }
 });
 async function pollLive() {
@@ -349,10 +429,12 @@ $('btnApplyTshark').addEventListener('click', async () => {
 });
 
 // ---------- 会话聚合（前端计算，对齐 GUI 的 ensureAnalytics）----------
+function aggSource() { return state.full !== null ? state.full : state.all; }
 function renderSessions() {
+    const all = aggSource();
     const cat = parseInt($('sessionCategory').value, 10);
     const map = new Map();
-    for (const p of state.all) {
+    for (const p of all) {
         if (!p.src_ip || !p.dst_ip) continue;
         const a = p.src_ip + ':' + p.src_port, b = p.dst_ip + ':' + p.dst_port;
         const key = a < b ? a + '|' + b : b + '|' + a;
@@ -383,9 +465,10 @@ $('sessionCategory').addEventListener('change', renderSessions);
 
 // ---------- 统计聚合 ----------
 function renderStats() {
+    const all = aggSource();
     const ip = new Map(), proto = new Map(), loc = new Map();
     const bump = (m, name, len) => { if (!name) return; const c = m.get(name) || { name, packets: 0, bytes: 0 }; c.packets++; c.bytes += len || 0; m.set(name, c); };
-    for (const p of state.all) {
+    for (const p of all) {
         bump(proto, p.protocol, p.len);
         bump(ip, p.src_ip, p.len); bump(ip, p.dst_ip, p.len);
         bump(loc, p.src_location, p.len); bump(loc, p.dst_location, p.len);
@@ -402,6 +485,41 @@ function drawStats() {
     $('statNameCol').textContent = state.statName === 'ip' ? 'IP 地址' : (state.statName === 'proto' ? '协议' : '归属地 / 国家');
     $('statsBody').innerHTML = items.map((c) =>
         `<tr><td>${escapeHtml(c.name)}</td><td>${c.packets}</td><td>${c.bytes}</td></tr>`).join('');
+    drawBars(items.slice(0, 12)); // 条形图只画 Top 12，避免拥挤
+}
+
+// 统计页的协议/IP/归属地横向条形图（原生 Canvas，无第三方依赖）
+function drawBars(items) {
+    const canvas = $('statsCanvas');
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const W = canvas.clientWidth || 600, H = canvas.clientHeight || 260;
+    canvas.width = W * dpr; canvas.height = H * dpr;
+    const ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, W, H);
+
+    if (!items.length) {
+        ctx.fillStyle = '#666'; ctx.font = '13px sans-serif';
+        ctx.fillText('（暂无数据）', 12, 30);
+        return;
+    }
+    const max = Math.max(...items.map((c) => c.packets), 1);
+    const rowH = Math.min(28, (H - 30) / items.length);
+    const labelW = 110, barW = W - labelW - 60;
+    items.forEach((c, i) => {
+        const y = 16 + i * rowH;
+        // 标签
+        ctx.fillStyle = '#9a9aa6'; ctx.font = '12px sans-serif';
+        ctx.fillText(escapeHtml(String(c.name)).slice(0, 16), 4, y + 12);
+        // 条形
+        const w = Math.max(2, (c.packets / max) * barW);
+        ctx.fillStyle = protocolClass(c.name);
+        ctx.fillRect(labelW, y, w, rowH - 8);
+        // 数值
+        ctx.fillStyle = '#d7d7db';
+        ctx.fillText(String(c.packets), labelW + w + 6, y + 12);
+    });
 }
 document.querySelectorAll('.stat-tab').forEach((b) => b.addEventListener('click', () => {
     document.querySelectorAll('.stat-tab').forEach((x) => x.classList.remove('active'));
@@ -410,22 +528,52 @@ document.querySelectorAll('.stat-tab').forEach((b) => b.addEventListener('click'
     drawStats();
 }));
 
+// ---------- 导出 CSV ----------
+$('btnExportCsv').addEventListener('click', async () => {
+    const path = $('csvPath').value.trim();
+    if (!path) { setStatus('请输入 CSV 保存路径'); return; }
+    setStatus('导出 CSV 中...');
+    try {
+        const r = await postJSON('/api/export/csv', { path });
+        setStatus('已导出 CSV: ' + r.path);
+    } catch (e) { setStatus('导出失败：' + e.message); }
+});
+
 // ---------- 分页 Tab 切换 ----------
 document.querySelectorAll('.tab').forEach((tab) => tab.addEventListener('click', () => {
     document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
     document.querySelectorAll('.tabpage').forEach((p) => p.classList.remove('active'));
     tab.classList.add('active');
     $('tab-' + tab.dataset.tab).classList.add('active');
+    // 统计/会话 Tab 首次进入时确保全量数据已就位（离线非直播场景）
+    if (!state.live.active && (tab.dataset.tab === 'stats' || tab.dataset.tab === 'sessions'))
+        ensureFull();
 }));
 
+// ---------- 令牌条 ----------
+$('btnTokenSave').addEventListener('click', () => {
+    const t = $('tokenInput').value.trim();
+    if (!t) { setStatus('请输入令牌'); return; }
+    authToken = t;
+    localStorage.setItem('easytshark_token', t);
+    $('tokenBar').style.display = 'none';
+    setStatus('令牌已保存');
+    init(); // 重新初始化（拉取 tshark 状态与报文快照）
+});
+
 // ---------- 初始化 ----------
-(async function init() {
+async function init() {
+    if (!authToken) {
+        $('tokenBar').style.display = 'flex'; // 尚无令牌：先让用户输入
+        return;
+    }
     try {
         const t = await getJSON('/api/tshark');
         $('tsharkPath').value = t.path;
-        $('tsharkState').textContent = t.available ? '✓ 可用' : '✗ 未找到 tshark';
-        $('tsharkState').style.color = t.available ? '#8ce673' : '#ff7373';
-    } catch (e) { /* 忽略 */ }
+        $('tsharkState').textContent = (t.available ? '✓ tshark 可用' : '内置引擎')
+            + (t.engine === 'native' ? '（native）' : '');
+        $('tsharkState').style.color = t.available ? '#8ce673' : '#ffb85a';
+    } catch (e) { /* 401 时 handleAuthError 已弹出令牌条 */ }
     try { await refreshSnapshot(); } catch (e) { /* 尚无数据，正常 */ }
     setStatus('就绪');
-})();
+}

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,13 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <!-- 访问令牌条：首次访问/令牌失效时显示；令牌存 localStorage 后隐藏 -->
+    <div id="tokenBar" class="tokenbar" style="display:none">
+        <span class="label">访问令牌（见服务器启动输出）</span>
+        <input id="tokenInput" type="password" placeholder="粘贴启动时打印的 Token" size="40">
+        <button id="btnTokenSave">保存</button>
+    </div>
+
     <!-- 工具栏：载入 pcap / 实时抓包 / tshark 路径 -->
     <div class="toolbar">
         <div class="tool-group">
@@ -26,6 +33,11 @@
             <input id="tsharkPath" type="text" placeholder="tshark 可执行文件完整路径" size="34">
             <button id="btnApplyTshark">应用</button>
             <span id="tsharkState" class="hint"></span>
+        </div>
+        <div class="tool-group">
+            <span class="label">导出</span>
+            <input id="csvPath" type="text" placeholder="CSV 保存路径，如 data/export.csv" size="24">
+            <button id="btnExportCsv">导出 CSV</button>
         </div>
     </div>
 
@@ -118,11 +130,16 @@
                 <button class="stat-tab" data-stat="proto">协议统计</button>
                 <button class="stat-tab" data-stat="loc">国家统计</button>
             </div>
-            <div class="table-scroll">
-                <table>
-                    <thead><tr><th id="statNameCol">IP 地址</th><th>包数</th><th>字节</th></tr></thead>
-                    <tbody id="statsBody"></tbody>
-                </table>
+            <div class="stats-layout">
+                <div class="stats-bars">
+                    <canvas id="statsCanvas" height="260"></canvas>
+                </div>
+                <div class="table-scroll">
+                    <table>
+                        <thead><tr><th id="statNameCol">IP 地址</th><th>包数</th><th>字节</th></tr></thead>
+                        <tbody id="statsBody"></tbody>
+                    </table>
+                </div>
             </div>
         </section>
 

--- a/web/style.css
+++ b/web/style.css
@@ -16,6 +16,14 @@ body { display: flex; flex-direction: column; }
 .label { color: #9a9aa6; font-size: 12px; }
 .hint { font-size: 12px; }
 
+/* 访问令牌条：黄色提示背景，输入框与“保存”按钮 */
+.tokenbar {
+    display: flex; gap: 8px; align-items: center;
+    padding: 8px 12px; background: #332b16; border-bottom: 1px solid #55471f;
+}
+.tokenbar .label { color: #e8d48a; }
+.tokenbar input { flex: 0 1 420px; }
+
 input[type=text], input:not([type]), select {
     background: #16161b; color: #e4e4ea; border: 1px solid #3a3a46;
     border-radius: 4px; padding: 4px 7px; font-size: 13px; outline: none;
@@ -53,6 +61,12 @@ button:disabled { opacity: .45; cursor: not-allowed; }
 
 /* 表格 */
 .table-scroll { flex: 1; overflow: auto; border: 1px solid #2e2e38; border-radius: 6px; }
+
+/* 统计页：左侧条形图 + 右侧表格并排 */
+.stats-layout { flex: 1; display: flex; gap: 12px; min-height: 0; }
+.stats-layout .table-scroll { flex: 1; }
+.stats-bars { width: 42%; min-width: 320px; border: 1px solid #2e2e38; border-radius: 6px; padding: 8px; }
+#statsCanvas { width: 100%; height: 100%; display: block; }
 table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 thead th {
     position: sticky; top: 0; background: #2a2a34; color: #c8c8d2;


### PR DESCRIPTION
将「内置引擎/Web 前端/协议扩展/性能/加固」多笔工作合并为一笔，并统一精简注释。

内置解析引擎（路线 B）
- 自研 pcap/pcapng 离线解析（NativeAnalyzer）+ 分层详情树 + 显示过滤子集
- libpcap 实时抓包（NativeCapture）；tshark 降级为可选增强，无 Wireshark 开箱即用
- 经典 pcap LE/BE/微秒/纳秒 统一为按字节序函子参数化的公共循环

应用层协议覆盖
- HTTP 请求/响应、TLS ClientHello+SNI、DNS 查询/响应(多应答)、DHCP、NTP、 ICMPv6 邻居发现、IP 分片标记；SLL/SLL2 链路层

三前端并列
- CLI(main) / ImGui GUI(main_gui) / Web(headless + 浏览器远程访问)
- Web 暴露当前引擎(tshark/native)，前端显示后端模式
- GUI 另存为：自动补 .pcap 后缀、覆盖确认、多层目录自动创建

性能
- mmap 零拷贝 viewAt、免堆分配、显示过滤编译一次、Release 默认优化

安全 / 并发 / 健壮性
- CSV 公式注入防护 + RFC 4180 转义修复
- setTsharkPath 切后端持 analyzerMutex_，消除 use-after-free（锁序 analyzerMutex_→mutex_）
- Web 令牌恒定时间比较、Origin==Host 防跨站、路径白名单、请求体 16MB 上限、strtoul 防越界
- pcapng EPB capLen 按块长度夹紧；SQLite prepare 失败 ROLLBACK

构建 / 测试
- 严格 -std=c++11（CMAKE_CXX_EXTENSIONS OFF）；测试目标单独 C++17
- 单元测试覆盖大端 pcap、pcapng(if_tsresol)、SLL/SLL2、另存为多层目录等；65 项运行用例通过

注释精简
- 跨 36 文件删除约 274 行冗长/复述式注释，仅保留解释关键「为什么」的注释；代码零改动