### PR TITLE
perf: 解析引擎/GUI/Web 全链路性能优化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(LIB_SOURCES
     src/NativeCapture.cpp
     src/xdb_search.cc
     src/processUtil.cpp
+    src/ProcessResolver.cpp
     src/web/WebServer.cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # EasyTshark - 网络数据包捕获与分析工具
 
 社区正式版由 **“轩辕之风”老师** 维护，见 [easytshark.com](https://www.easytshark.com/)。
+> 早期未完成的实现（仅含后端部分，无 GUI）保存在本仓库 [`feature/V1`](../../tree/feature/V1) 分支；当前分支是用AI重构后的版本。
 
 EasyTshark 支持实时抓包与离线 PCAP 分析、SQLite 存储、XML/JSON 格式转换，提供**命令行**、**原生图形界面**与**Web 界面**三种前端。
 
-**无需预装 Wireshark 即可开箱即用**：项目内置自研解析引擎（libpcap 抓包 + 内置协议解析），覆盖常用协议（Ethernet/VLAN/ARP/IPv4/IPv6/ICMP/TCP/UDP/DNS/HTTP/TLS/SSH 等）。安装 Wireshark 的 tshark 后可解锁**完整协议详情树、显示过滤、流量趋势**等增强能力（自动检测，无需配置）。
-
-> 早期未完成的实现（仅含后端部分，无 GUI）保存在 [`feature/V1`](../../tree/feature/V1) 分支；当前主线是重构后的完整版本。
+**无需预装 Wireshark 即可开箱即用**：项目内置自研解析引擎（libpcap 抓包 + 内置协议解析），覆盖常用协议（Ethernet/VLAN/ARP/IPv4/IPv6/ICMP/TCP/UDP/DNS/HTTP/TLS/SSH 等）与**汽车诊断协议**（DoIP / UDS / CAN / CAN FD）。安装 Wireshark 的 tshark 后可解锁**完整协议详情树、显示过滤、流量趋势**等增强能力（自动检测，无需配置）。
 
 ![图形界面](images/easytshark_gui.png)
 
@@ -19,6 +18,7 @@ EasyTshark 支持实时抓包与离线 PCAP 分析、SQLite 存储、XML/JSON �
 - **格式转换**：PCAP → tshark PDML(XML) → JSON；报文快照可导出 CSV（Web 界面有导出按钮）；离线分析支持 **pcapng**（自动识别，hex 视图正确）
 - **IP 地理位置**：基于 ip2region 自动解析归属地（库文件缺失时优雅降级为空归属地，不再退出程序）
 - **tshark 自动探测**：依次尝试环境变量 `EASYTSHARK_TSHARK`、平台默认路径、`PATH`、Windows 注册表；也可手动指定（无需重编译）
+- **汽车诊断协议**：DoIP（ISO 13400-2，TCP/UDP 13400，含车辆识别/路由激活/诊断消息）、UDS（ISO 14229-1，SID 服务名 + 正/负响应 + NRC 解释）、CAN/CAN FD（SocketCAN DLT 227 / 原始 CAN 228 / CAN FD 229 链路类型，EFF 扩展帧、BRS/ESI 标志、ISO-TP 单帧解包），支持显示过滤 `doip` / `uds` / `can` / `can.id`
 - **查询**：支持 MAC / IP / 端口 / 归属地模糊匹配（`*` 通配；字面 `%`/`_` 已转义），结果可导出 JSON
 - **Web 安全**：所有 `/api/*` 需 `X-Auth-Token`（启动时生成打印，可用 `EASYTSHARK_WEB_TOKEN`/`--token` 固定）+ Origin 校验；`/api/load` 与导出限用户主目录/`data/` 下
 - **大文件**：Web 报文列表分页拉取、实时缓冲有上限（长抓包丢弃最旧）；统计页带协议/IP 分布条形图

--- a/include/AnalysisSession.hpp
+++ b/include/AnalysisSession.hpp
@@ -14,6 +14,7 @@
 #include "NativeCapture.hpp"
 #include "PcapAnalyzer.hpp"
 #include "PdmlToJsonConverter.hpp"
+#include "ProcessResolver.hpp"
 #include "tsharkDataType.hpp"
 #include "utils.hpp"
 
@@ -115,6 +116,9 @@ private:
     // nativeAnalyzer_ 仅在 native_ 时使用；与 analyzer_ 同受 analyzerMutex_ 保护。
     bool                           native_ = false;
     std::unique_ptr<NativeAnalyzer> nativeAnalyzer_;
+
+    // 实时抓包时反查每个包的归属进程；仅 macOS/Linux 生效，其他平台/离线回放恒为 no-op。
+    std::unique_ptr<ProcessResolver> processResolver_;
 
     // 保护 packets_ 快照（原子交换的 shared_ptr，读写双方均持锁拷贝引用计数）
     mutable std::mutex                                                       mutex_;

--- a/include/NativeAnalyzer.hpp
+++ b/include/NativeAnalyzer.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "NativePacketParser.hpp"
 #include "PcapFileReader.hpp"
 #include "tsharkDataType.hpp"
 
@@ -39,6 +40,11 @@ private:
     // 文件链路层类型（供 getPacketDetailTree 正确重解析：Ethernet/NULL/SLL 等）。
     int  linkType_ = 1;
     bool analyzed_ = false;
+
+    // CAN 详情查询的增量重放缓存：canReplayCache_ 已喂入帧 [1, canReplayedUpTo_]，
+    // 顺序浏览时只需再喂入 1 帧而非从头重放全部历史帧。乱序往回跳时整体重置重放。
+    mutable NativePacketParser::IsoTpReassembler canReplayCache_;
+    mutable uint32_t                             canReplayedUpTo_ = 0;
 };
 
 #endif

--- a/include/NativePacketParser.hpp
+++ b/include/NativePacketParser.hpp
@@ -4,15 +4,46 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "tsharkDataType.hpp"
 
 // 自研协议解析引擎：原始帧字节 → 与 tshark -T fields 对齐的 Packet。供无 tshark 环境兜底。
-// 覆盖 Ethernet(VLAN/QinQ) / ARP / IPv4 / IPv6 / ICMP / ICMPv6(ND) / TCP / UDP，
-// 应用层 DNS / HTTP / TLS(SNI) / DHCP / NTP / SSH 等；只覆盖展示所需字段，不做完整协议语义。
+// 覆盖 Ethernet(VLAN/QinQ) / ARP / IPv4 / IPv6(含分片) / ICMP / ICMPv6(ND) / TCP / UDP，
+// 应用层 DNS(含压缩指针) / HTTP / TLS(SNI) / DHCP / NTP / SSH(版本交换 banner)，
+// 以及汽车诊断 DoIP / UDS / CAN(CAN FD，含 ISO-TP 多帧重组)
+// （SocketCAN DLT 227 / 原始 CAN 228 / CAN FD 229 链路）；只覆盖展示所需字段，不做完整协议语义。
 namespace NativePacketParser
 {
+// ISO-TP（ISO 15765-2）跨 CAN 帧重组器：按 can_id 维护挂起会话，把 First Frame + Consecutive Frame
+// 序列还原成完整负载（通常是较长的 UDS 报文）。Flow Control 帧不携带负载，不进入会话状态。
+// 单帧（SF）不经过此类：parseCan 对 SF 直接原地解析，无需跨帧状态。
+class IsoTpReassembler
+{
+public:
+    enum Kind { kNone, kFirstFrame, kConsecutive, kFlowControl };
+    struct Result
+    {
+        Kind     kind      = kNone;
+        bool     completed = false; // 本帧是否恰好补满一条完整负载
+        uint16_t seq       = 0;     // Consecutive Frame 的序号（低 4 位）
+        uint16_t totalLen  = 0;     // First Frame 声明的总长度
+        std::vector<unsigned char> payload; // completed 时：重组后的完整负载
+    };
+    // data/len：该 CAN 帧的数据区（含 ISO-TP PCI 字节）。非 FF/CF/FC 返回 kind=kNone，不改变状态。
+    Result feed(uint32_t canId, const unsigned char* data, uint32_t len);
+
+private:
+    struct Session
+    {
+        uint32_t                   expectedLen = 0;
+        std::vector<unsigned char> buf;
+        uint8_t                    nextSeq = 1;
+    };
+    std::unordered_map<uint32_t, Session> sessions_;
+};
+
 // 应用层协议详情（供完整协议树与增强 info 使用）。
 struct ProtocolDetail
 {
@@ -26,18 +57,41 @@ struct ProtocolDetail
     std::string httpHost;    // Host header
     // TLS
     bool        tls = false;
-    std::string tlsType;    // "Client Hello" / "Server Hello" / "Certificate" ...
-    std::string tlsVersion; // "TLS 1.2" ...
+    const char* tlsType = nullptr;    // "Client Hello" / "Server Hello" / "Application Data" ...
+    const char* tlsVersion = nullptr; // "TLS 1.2" ...（未识别的版本号时为空）
     std::string tlsSni;     // SNI 扩展里的服务器名
     // DNS 响应回答摘要（"A 93.184.216.34, AAAA 2606:... "）
     std::string dnsAnswers;
+    // SSH（RFC 4253，仅明文版本交换阶段）
+    bool        ssh = false;
+    std::string sshVersion; // 版本交换 banner，如 "SSH-2.0-OpenSSH_8.9"
     // DHCP
     bool        dhcp = false;
-    std::string dhcpType; // Discover / Offer / Request / Ack ...
+    const char* dhcpType = nullptr; // Discover / Offer / Request / Ack ...（magic cookie 校验失败时为空）
     // NTP
     bool        ntp = false;
     std::string ntpDesc;
-    // IP 分片
+    // DoIP（ISO 13400-2，TCP/UDP 13400 端口）
+    bool        doip = false;
+    std::string doipVersion;      // 协议版本描述（"ISO 13400-2:2012" 等）
+    uint16_t    doipType = 0;     // 负载类型码（0x0001 Vehicle identification request ...）
+    const char* doipDesc = nullptr; // 负载类型补充描述（如 ACK 的正/负；仅部分类型有）
+    // UDS（ISO 14229-1，DoIP 诊断消息负载或 CAN 报文负载）
+    bool        uds = false;
+    std::string udsService;   // 服务名 + SID（如 "DiagnosticSessionControl (0x10)"）
+    bool        udsResponse = false; // 是否响应帧（正响应 0x40+SID 或负响应 0x7F）
+    std::string udsNrc;       // 负响应码名称（0x7F 时，如 "Service not supported"）
+    // CAN（SocketCAN DLT 227 / 原始 CAN 228 / CAN FD 229）
+    bool        can = false;
+    const char* canKind = nullptr; // "CAN" / "CAN FD"（含 BRS/ESI 附加标记）；detail.can 为真时必非空
+    uint32_t    canId = 0;    // 去掉 EFF/RTR/ERR 标志后的 CAN ID
+    bool        canExtended = false; // 29 位扩展帧（EFF）
+    // ISO-TP 多帧（FF/CF/FC；SF 走既有 uds 字段，不设置这组字段）
+    bool        isoTpFrame = false;
+    const char* isoTpKind = nullptr; // "First Frame" / "Consecutive Frame" / "Flow Control"
+    uint16_t    isoTpSeq = 0;        // Consecutive Frame 的序号
+    uint16_t    isoTpTotalLen = 0;   // First Frame 声明的总长度
+    // IP 分片（IPv4 与 IPv6 Fragment Header 共用）
     bool     ipFragmented = false;
     uint16_t fragOffset   = 0;
     bool     fragMore     = false;
@@ -45,12 +99,18 @@ struct ProtocolDetail
 
 // 解析一个原始帧，填充 packet。成功返回 true；帧太短/格式异常返回 false（不抛异常、不崩溃）。
 // linkType：0 = NULL/Loopback（BSD lo，前 4 字节地址族），1 = Ethernet，-1 = 自动检测。
-bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType = -1);
+// isoTp：非空时用于跨帧累积 ISO-TP 状态（CAN 链路多帧场景），调用方负责在同一序列的帧之间共享同一实例。
+bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType = -1,
+                IsoTpReassembler* isoTp = nullptr);
 
-// 完整协议树：从原始帧重建（含应用层分层：HTTP/TLS/DNS/DHCP 子层、IP 分片标记）。
-// root 需预先为 DetailNode()（调用方负责）。
+// 完整协议树：从原始帧重建（含应用层分层：HTTP/TLS/DNS/DHCP/DoIP/UDS/SSH 子层、CAN 层、IP 分片标记）。
+// root 需预先为 DetailNode()（调用方负责）。isoTp 语义同 parseFrame。
 bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint32_t frameNumber,
-                     DetailNode& root);
+                     DetailNode& root, IsoTpReassembler* isoTp = nullptr);
+
+// 仅把一帧 CAN/CAN FD 原始帧喂给重组器（不生成 Packet/DetailNode）。
+// 用于按需重建详情树前，重放同一 CAN 链路上先前的帧以预热跨帧状态。
+void feedCanFrame(const unsigned char* data, uint32_t len, int linkType, IsoTpReassembler& isoTp);
 
 // 判断显示过滤表达式是否命中一个报文（自研子集）。
 // 支持的字段：
@@ -58,7 +118,8 @@ bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint
 //   eth.addr / eth.src / eth.dst（MAC）
 //   ip.addr / ip.src / ip.dst / ipv6.addr / ipv6.src / ipv6.dst（IP）
 //   tcp.port / tcp.srcport / tcp.dstport / udp.port / udp.srcport / udp.dstport（整数）
-//   协议存在性：tcp udp arp icmp icmpv6 dns http tls ssl ssh dhcp ntp（无操作数）
+//   can.id（整数，支持 0x 前缀十六进制）
+//   协议存在性：tcp udp arp icmp icmpv6 dns http tls ssl ssh dhcp ntp doip uds can（无操作数）
 // 操作符：== !=   逻辑：&& || !   支持括号。
 // 返回 true 表示表达式合法且命中；expr 非法时置 *err 并返回 false。
 bool matchDisplayFilter(const std::string& expr, const Packet& packet,

--- a/include/ProcessResolver.hpp
+++ b/include/ProcessResolver.hpp
@@ -1,0 +1,34 @@
+#ifndef ProcessResolver_hpp
+#define ProcessResolver_hpp
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+struct Packet;
+
+// 实时抓包时把报文反查到本机产生它的进程（Wireshark 式"进程列"）。
+// 只能解析当前用户自己的 socket（除非以 root 运行），且只在 macOS / Linux 生效；
+// 其他平台 annotate() 恒为 no-op（沿用项目里"不支持平台优雅降级"的惯例）。
+class ProcessResolver
+{
+public:
+    // 按包的 src_port/dst_port + transport 查表回填 proc_name/proc_pid；未命中时不改动包。
+    void annotate(Packet& packet);
+
+private:
+    // 内部按节流间隔重新扫描整张 socket→进程表，避免每包都重新 lsof / 扫 /proc。
+    void refreshIfStale();
+    void refreshMacOS(); // #if defined(__APPLE__)
+    void refreshLinux();  // #elif defined(__linux__)
+
+    std::mutex                                                mutex_;
+    std::chrono::steady_clock::time_point                     lastRefresh_{};
+    // key = (isUdp ? 1<<16 : 0) | port；value = (进程名, pid)
+    std::unordered_map<uint32_t, std::pair<std::string, int>> table_;
+};
+
+#endif

--- a/include/processUtil.hpp
+++ b/include/processUtil.hpp
@@ -28,60 +28,25 @@ public:
     /// 句柄是否指向一个已成功创建、尚未回收的子进程。
     static bool ValidProc(ProcHandle h);
 
-    /**
-     * @brief 执行命令并等待完成
-     * @warning 该重载通过 shell（POSIX: /bin/sh -c，Windows: cmd.exe /c）执行，
-     *          命令中的元字符会被解释，存在注入风险。传入不可信输入时请改用 argv 向量重载。
-     */
+    // @warning 该重载通过 shell（POSIX: /bin/sh -c，Windows: cmd.exe /c）执行，
+    // 命令中的元字符会被解释，存在注入风险。传入不可信输入时请改用 argv 向量重载。
     static bool Exec(const char* command);
 
-    /**
-     * @brief 执行命令并等待完成（安全版：不经过 shell）
-     * @param argv 参数向量，argv[0] 为可执行程序，其余为参数；不会被 shell 解释
-     * @return true 子进程正常退出且返回 0
-     */
     static bool Exec(const std::vector<std::string>& argv);
 
-    /**
-     * @brief 扩展的 popen，返回子进程句柄
-     * @param pid 输出参数，存储子进程句柄（POSIX: pid_t，Windows: 进程 HANDLE）
-     * @param type 打开模式 ("r" 或 "w")，默认 "r"
-     * @return FILE* 管道文件指针，失败返回 nullptr
-     * @warning 经由 shell 执行，存在注入风险；不可信输入请改用 argv 向量重载。
-     */
+    // @warning 经由 shell 执行，存在注入风险；不可信输入请改用 argv 向量重载。
     static FILE* PopenEx(const char* command, ProcHandle* pid, const char* type = "r");
 
-    /**
-     * @brief 扩展的 popen（安全版：不经过 shell）
-     * @param argv 参数向量，argv[0] 为可执行程序名，其余为参数；不会被 shell 解释
-     * @param pid 输出参数，存储子进程句柄
-     * @param type 打开模式 ("r" 或 "w")，默认 "r"
-     * @return FILE* 管道文件指针，失败返回 nullptr
-     */
     static FILE* PopenEx(const std::vector<std::string>& argv, ProcHandle* pid,
                          const char* type = "r", bool mergeStderr = false);
 
-    /**
-     * @brief 终止指定子进程并回收
-     * @param pid 子进程句柄
-     * @note POSIX 发 SIGTERM 后 waitpid 回收；Windows 用 TerminateProcess 后 CloseHandle。
-     */
+    // POSIX 发 SIGTERM 后 waitpid 回收；Windows 用 TerminateProcess 后 CloseHandle。
     static bool Kill(ProcHandle pid);
 
-    /**
-     * @brief 请求子进程终止，但**不回收**（不 waitpid / 不 CloseHandle）
-     * @param pid 子进程句柄
-     * @note 供“发信号收尾 + 由配套 PcloseEx 单点回收”的场景使用，避免与 PcloseEx 争抢回收
-     *       造成双重 waitpid / CloseHandle。POSIX 发 SIGTERM；Windows 用 TerminateProcess。
-     */
+    // 只请求终止、不回收（不 waitpid / 不 CloseHandle）：供“发信号收尾 + 由配套 PcloseEx
+    // 单点回收”的场景使用，避免与 PcloseEx 争抢回收造成双重 waitpid / CloseHandle。
     static bool Signal(ProcHandle pid);
 
-    /**
-     * @brief 关闭 PopenEx 返回的管道并回收子进程
-     * @param pipe PopenEx 返回的 FILE*
-     * @param pid  PopenEx 输出的子进程句柄
-     * @return 子进程退出状态；pipe 为空时返回 -1
-     */
     static int PcloseEx(FILE* pipe, ProcHandle pid);
 };
 

--- a/include/tsharkDataType.hpp
+++ b/include/tsharkDataType.hpp
@@ -27,6 +27,18 @@ struct Packet
     uint64_t file_offset = 0;
     // 传输层协议（"TCP"/"UDP"/""）：仅内存态、不入库，供 GUI 会话视图区分 TCP/UDP。
     std::string transport;
+    // CAN 帧 ID（SocketCAN/原始 CAN 链路）：去掉 EFF/RTR/ERR 标志后的 11/29 位 ID，非 CAN 帧为 0。
+    // 仅内存态、不入库，供显示过滤（can.id）使用。
+    uint32_t can_id = 0;
+    // 是否 DoIP 帧（含携带 UDS 的诊断消息，此时 protocol 为 "UDS"）：仅内存态，供显示过滤（doip）使用。
+    bool is_doip = false;
+    // 实时抓包时反查到的归属进程（本机 socket→PID 映射，仅当前用户权限内可解析）：
+    // 仅内存态、不入库；离线回放 pcap 时 socket 已不存在，恒为空/0。
+    std::string proc_name;
+    int         proc_pid = 0;
+    // GUI 表格每帧都重画可见行，即使这些包的数据早已不变；显示时间戳格式化字符串懒缓存于此，
+    // 首次绘制后各帧复用，不必每帧重新格式化。跟随 Packet 生命周期，无需单独失效逻辑。
+    std::string display_time_cache;
 };
 
 // 协议分层树节点：承载展示用文本（label/value/children），供详情面板递归展开。
@@ -35,6 +47,9 @@ struct DetailNode
     std::string             label; // 显示名（PDML showname，回退到 name）
     std::string             value; // 取值（PDML show，回退到 value）
     std::vector<DetailNode> children;
+    // 叶子节点的 "label: value" 拼接懒缓存：详情面板选中一个包后会持续多帧重画同一棵树，
+    // 树本身在下次选中新包前不变，缓存避免每帧重新拼接。
+    std::string display_text_cache;
 };
 
 struct PcapHeader

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -50,6 +50,18 @@ public:
      * @note 内部用 StringRef 引用 packets 的字符串内存，序列化期间入参须保持存活。
      */
     static std::string packetsToJson(const std::vector<std::shared_ptr<Packet>>& packets);
+
+    // 直接写入调用方 allocator 的 rapidjson 数组重载：供调用方把结果嵌进自己的 Document
+    // （如分页响应 {total,page,packets:[...]}），省去 packetsToJson 那版
+    // 序列化成字符串再 Parse 回 DOM 再深拷贝合并的三次往返。
+    static rapidjson::Value packetsToJsonValue(const std::vector<std::shared_ptr<Packet>>& packets,
+                                               rapidjson::Document::AllocatorType& allocator);
+    // 迭代器区间版本：分页切片场景直接传原快照的迭代器区间，不必先拷出一段
+    // vector<shared_ptr<Packet>>（每个元素都是一次原子 incref/decref）。
+    static rapidjson::Value
+    packetsToJsonValue(std::vector<std::shared_ptr<Packet>>::const_iterator begin,
+                       std::vector<std::shared_ptr<Packet>>::const_iterator end,
+                       rapidjson::Document::AllocatorType&                  allocator);
 };
 
 /**

--- a/src/AnalysisSession.cpp
+++ b/src/AnalysisSession.cpp
@@ -3,7 +3,6 @@
 #include <cerrno>
 #include <cstdio>
 #include <fstream>
-#include <set>
 #include <sys/stat.h>
 
 #if defined(_WIN32)
@@ -94,7 +93,8 @@ AnalysisSession::AnalysisSession(const std::string& tsharkPath, const std::strin
       // 初始为空快照（非 null）：调用方无需检查空指针即可安全解引用。
       packets_(std::make_shared<const std::vector<std::shared_ptr<Packet>>>()),
       // 后端选择：tshark 不可用时降级到自研引擎（libpcap + 内置解析），否则优先用 tshark。
-      native_(!TsharkCommand::tsharkAvailable(tsharkPath))
+      native_(!TsharkCommand::tsharkAvailable(tsharkPath)),
+      processResolver_(new ProcessResolver())
 {
     if (native_)
     {
@@ -150,7 +150,6 @@ bool AnalysisSession::loadPcap(const std::string& srcPath)
         return false;
     }
 
-    // 按时间戳留一份到 pcaps 目录，历史不覆盖；db 与之一一对应。
     std::string ts       = CommonUtil::get_timestamp();
     std::string destPcap = pcapsDir_ + "/capture_" + ts + ".pcap";
     std::string destDb   = pcapsDir_ + "/packets_" + ts + ".db";
@@ -267,7 +266,8 @@ bool AnalysisSession::queryDisplayFilter(const std::string&                    d
         }
     }
     // 从既有快照按帧号取报文，沿用快照里权威的 file_offset，过滤结果仍能正确取 hex。
-    std::set<uint32_t> keep(frames.begin(), frames.end());
+    // frames（getFramesByDisplayFilter 按 packets_ 顺序产出）与 *snap 都已按 frame_number
+    // 升序排列，双指针归并一次线性扫描即可，无需再建 set 后逐元素 count() 查找。
     std::shared_ptr<const std::vector<std::shared_ptr<Packet>>> snap;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -277,11 +277,16 @@ bool AnalysisSession::queryDisplayFilter(const std::string&                    d
     {
         return false;
     }
+    size_t fi = 0;
     for (const std::shared_ptr<Packet>& p : *snap)
     {
-        if (keep.count(static_cast<uint32_t>(p->frame_number)) > 0)
+        uint32_t fn = static_cast<uint32_t>(p->frame_number);
+        while (fi < frames.size() && frames[fi] < fn)
+            ++fi;
+        if (fi < frames.size() && frames[fi] == fn)
         {
             out.push_back(p);
+            ++fi;
         }
     }
     return true;
@@ -413,7 +418,7 @@ bool AnalysisSession::exportPacketsCsv(const std::string& csvPath)
     char timeBuf[64];
     for (const std::shared_ptr<Packet>& p : *snap)
     {
-        // time 是 epoch 浮点秒，转成可读时间戳（毫秒精度）
+        // time 是 epoch 浮点秒，格式化成保留 3 位小数的字符串（毫秒精度）
         std::snprintf(timeBuf, sizeof(timeBuf), "%.3f", p->time);
         out << p->frame_number << ',' << timeBuf << ','
             << csvField(p->src_mac) << ',' << csvField(p->src_ip) << ',' << csvField(p->src_location)
@@ -444,16 +449,25 @@ bool AnalysisSession::startLiveCapture(const std::string&           adapterName,
         LOG_F(WARNING, "已在抓包中，忽略重复的开始请求");
         return false;
     }
-    // 按时间戳直接写入 pcaps 目录，历史不覆盖。
     std::string ts   = CommonUtil::get_timestamp();
     liveCapturePath_ = pcapsDir_ + "/capture_" + ts + ".pcap";
     liveDbPath_      = pcapsDir_ + "/packets_" + ts + ".db";
+
+    // 两条抓包引擎的 PacketCallback 类型完全一致，包一层即可让二者同时获得进程归属能力：
+    // 离线回放不会走这条路径，故 proc_name/proc_pid 天然只在实时抓包时被填充。
+    ProcessResolver*             resolver = processResolver_.get();
+    LiveCapture::PacketCallback  wrapped  = [onPacket, resolver](const std::shared_ptr<Packet>& p)
+    {
+        resolver->annotate(*p);
+        if (onPacket)
+            onPacket(p);
+    };
 
     if (native_)
     {
         // 自研抓包：libpcap 直接抓，无需 tshark 路径。
         nativeCapture_.reset(new NativeCapture());
-        if (!nativeCapture_->startCapture(adapterName, std::move(onPacket), liveCapturePath_,
+        if (!nativeCapture_->startCapture(adapterName, std::move(wrapped), liveCapturePath_,
                                           durationSeconds))
         {
             nativeCapture_.reset();
@@ -463,7 +477,7 @@ bool AnalysisSession::startLiveCapture(const std::string&           adapterName,
     else
     {
         capture_.reset(new LiveCapture(tsharkPath_));
-        if (!capture_->startCapture(adapterName, std::move(onPacket), liveCapturePath_,
+        if (!capture_->startCapture(adapterName, std::move(wrapped), liveCapturePath_,
                                     durationSeconds))
         {
             capture_.reset();

--- a/src/NativeAnalyzer.cpp
+++ b/src/NativeAnalyzer.cpp
@@ -50,10 +50,11 @@ bool isPcapNg(const unsigned char* p)
 }
 
 // 只保留能正确解析的链路类型；未知类型按 Ethernet 兜底。
-// 0=NULL/Loopback，1=Ethernet，113=Linux SLL，276=Linux SLL2。
+// 0=NULL/Loopback，1=Ethernet，113=Linux SLL，276=Linux SLL2，
+// 227=CAN SocketCAN，228=CAN，229=CAN FD（汽车诊断/总线抓包）。
 uint32_t normalizeLinkType(uint32_t lt)
 {
-    if (lt == 0 || lt == 1 || lt == 113 || lt == 276)
+    if (lt == 0 || lt == 1 || lt == 113 || lt == 276 || lt == 227 || lt == 228 || lt == 229)
         return lt;
     return 1;
 }
@@ -103,11 +104,24 @@ void parseIdb(const unsigned char* blk, uint32_t total, uint32_t& linkType, doub
     }
 }
 
+// 字节序读取仿函数：无状态，operator() 在模板参数位置传入时编译期已知目标，可被内联
+// （相比函数指针参数，避免运行期间接调用）。
+struct LeRead32
+{
+    uint32_t operator()(const unsigned char* p) const { return rdLe32(p); }
+};
+struct BeRead32
+{
+    uint32_t operator()(const unsigned char* p) const { return rdBe32(p); }
+};
+
 // 经典 pcap 记录遍历（24 字节全局头 + 16 字节记录头 + 数据）。LE/BE/微秒/纳秒四种组合仅字节序与
-// 时间戳单位不同，故用读取函子 rd32（rdLe32/rdBe32）与除数 tsDiv（1e6/1e9）参数化，共用一份循环。
+// 时间戳单位不同，故用读取仿函数 Read32（LeRead32/BeRead32）与除数 tsDiv（1e6/1e9）参数化，共用一份循环。
+template <typename Read32>
 void parseClassicPcap(PcapFileReader& reader, uint64_t fileSize,
-                      uint32_t (*rd32)(const unsigned char*), double tsDiv, int linkType,
-                      std::vector<std::shared_ptr<Packet>>& packets)
+                      Read32 rd32, double tsDiv, int linkType,
+                      std::vector<std::shared_ptr<Packet>>& packets,
+                      NativePacketParser::IsoTpReassembler* isoTp)
 {
     uint64_t pos   = 24;
     int      frame = 1;
@@ -136,7 +150,7 @@ void parseClassicPcap(PcapFileReader& reader, uint64_t fileSize,
         p.cap_len      = caplen;
         p.len          = origlen ? origlen : caplen;
         p.file_offset  = dataOff;
-        NativePacketParser::parseFrame(data, caplen, p, linkType);
+        NativePacketParser::parseFrame(data, caplen, p, linkType, isoTp);
 
         packets.push_back(std::make_shared<Packet>(std::move(p)));
         pos += 16 + static_cast<uint64_t>(caplen);
@@ -151,6 +165,8 @@ bool NativeAnalyzer::analyzeFile(const std::string& filePath,
     packets_.clear();
     analyzed_  = false;
     linkType_  = 1;
+    canReplayCache_  = NativePacketParser::IsoTpReassembler();
+    canReplayedUpTo_ = 0;
 
     if (!reader_.open(filePath))
     {
@@ -171,9 +187,13 @@ bool NativeAnalyzer::analyzeFile(const std::string& filePath,
         return false;
     }
 
+    // 跨帧 ISO-TP 状态：整份文件共享一个重组器，三处 parseFrame 调用（经典 pcap / pcapng EPB / SPB）
+    // 都喂给它，保证顺序解析时同一 CAN 总线上的多帧 UDS 报文能被正确累积。
+    NativePacketParser::IsoTpReassembler isoTp;
+
     if (isPcapLe(head) || isPcapLeNano(head))
     {
-        // 经典小端 pcap：24 字节全局头 + 16 字节记录头。微秒版除数 1e6，纳秒版 1e9。
+        // 微秒版除数 1e6，纳秒版 1e9。
         const unsigned char* gh = reader_.viewAt(0, 24);
         if (!gh)
             return false;
@@ -181,18 +201,17 @@ bool NativeAnalyzer::analyzeFile(const std::string& filePath,
         uint32_t linkType = normalizeLinkType(rdLe32(gh + 20));
         linkType_         = static_cast<int>(linkType);
         double tsDiv      = isPcapLeNano(head) ? 1e9 : 1e6;
-        parseClassicPcap(reader_, fileSize, &rdLe32, tsDiv, static_cast<int>(linkType), packets_);
+        parseClassicPcap(reader_, fileSize, LeRead32(), tsDiv, static_cast<int>(linkType), packets_, &isoTp);
     }
     else if (isPcapBe(head) || isPcapBeNano(head))
     {
-        // 经典大端 pcap：同布局，字段大端。
         const unsigned char* gh = reader_.viewAt(0, 24);
         if (!gh)
             return false;
         uint32_t linkType = normalizeLinkType(rdBe32(gh + 20));
         linkType_         = static_cast<int>(linkType);
         double tsDiv      = isPcapBeNano(head) ? 1e9 : 1e6;
-        parseClassicPcap(reader_, fileSize, &rdBe32, tsDiv, static_cast<int>(linkType), packets_);
+        parseClassicPcap(reader_, fileSize, BeRead32(), tsDiv, static_cast<int>(linkType), packets_, &isoTp);
     }
     else if (isPcapNg(head))
     {
@@ -252,7 +271,7 @@ bool NativeAnalyzer::analyzeFile(const std::string& filePath,
                 p.cap_len      = capLen;
                 p.len          = origLen ? origLen : capLen;
                 p.file_offset  = dataOff;
-                NativePacketParser::parseFrame(data, capLen, p, lt);
+                NativePacketParser::parseFrame(data, capLen, p, lt, &isoTp);
                 packets_.push_back(std::make_shared<Packet>(std::move(p)));
                 ++frame;
             }
@@ -276,7 +295,7 @@ bool NativeAnalyzer::analyzeFile(const std::string& filePath,
                 p.cap_len      = capLen;
                 p.len          = origLen;
                 p.file_offset  = dataOff;
-                NativePacketParser::parseFrame(data, capLen, p, lt);
+                NativePacketParser::parseFrame(data, capLen, p, lt, &isoTp);
                 packets_.push_back(std::make_shared<Packet>(std::move(p)));
                 ++frame;
             }
@@ -314,7 +333,32 @@ bool NativeAnalyzer::getPacketDetailTree(uint32_t frameNumber, DetailNode& root)
     const unsigned char* raw = reader_.viewAt(p.file_offset, p.cap_len);
     if (!raw)
         return false;
-    return NativePacketParser::buildDetailTree(raw, p.cap_len, linkType_, frameNumber, root);
+
+    // CAN 链路：需要此帧之前所有历史帧预热重组器状态，才能让中间的 Consecutive Frame 也显示
+    // 完整重组后的 UDS 内容。canReplayCache_ 缓存"已喂入到第几帧"，顺序浏览（UI 常见操作）时
+    // 只需增量喂入新增的那几帧；往回跳到更早的帧才需要整体重置重放（详见头文件字段注释）。
+    bool     isCanLink = (linkType_ == 227 || linkType_ == 228 || linkType_ == 229);
+    uint32_t target    = frameNumber - 1; // 需要喂入的历史帧数（此帧之前的帧）
+    if (isCanLink)
+    {
+        if (canReplayedUpTo_ > target)
+        {
+            canReplayCache_  = NativePacketParser::IsoTpReassembler();
+            canReplayedUpTo_ = 0;
+        }
+        for (; canReplayedUpTo_ < target; ++canReplayedUpTo_)
+        {
+            const Packet&         hp   = *packets_[canReplayedUpTo_];
+            const unsigned char*  praw = reader_.viewAt(hp.file_offset, hp.cap_len);
+            if (praw)
+                NativePacketParser::feedCanFrame(praw, hp.cap_len, linkType_, canReplayCache_);
+        }
+    }
+    // 用缓存状态的一份拷贝喂给 buildDetailTree：它内部还会 feed 当前帧本身，那次 feed 不应
+    // 污染缓存（缓存语义是"已喂入到 target 帧"，当前帧尚未计入）。
+    NativePacketParser::IsoTpReassembler isoTp = canReplayCache_;
+    return NativePacketParser::buildDetailTree(raw, p.cap_len, linkType_, frameNumber, root,
+                                               isCanLink ? &isoTp : nullptr);
 }
 
 bool NativeAnalyzer::getFramesByDisplayFilter(const std::string& expr,

--- a/src/NativeCapture.cpp
+++ b/src/NativeCapture.cpp
@@ -13,7 +13,6 @@
 
 namespace
 {
-// 写经典小端 pcap 全局头
 void writePcapGlobalHeader(FILE* f)
 {
     // magic d4c3b2a1 + 2.4 + thiszone 0 + sigfigs 0 + snaplen 65535 + network 1(Ethernet)
@@ -157,6 +156,8 @@ void NativeCapture::workThread(std::string adapterName, PacketCallback onPacket,
           captureFile.c_str(), dl);
     auto   startTime = std::chrono::steady_clock::now();
     int    frame     = 1;
+    // 跨包保留状态：实时抓包场景下同一 CAN 总线的多帧 UDS 报文也需要按到达顺序重组。
+    NativePacketParser::IsoTpReassembler isoTp;
     while (!stopFlag_)
     {
         // 时长限制：到点退出（等价 tshark -a duration:N）
@@ -180,9 +181,9 @@ void NativeCapture::workThread(std::string adapterName, PacketCallback onPacket,
                              static_cast<double>(hdr->ts.tv_usec) / 1e6;
             p.cap_len = hdr->caplen;
             p.len     = hdr->len;
-            NativePacketParser::parseFrame(data, hdr->caplen, p, linkType);
+            NativePacketParser::parseFrame(data, hdr->caplen, p, linkType, &isoTp);
             if (onPacket)
-                onPacket(std::make_shared<Packet>(p));
+                onPacket(std::make_shared<Packet>(std::move(p)));
         }
         else if (rc == -1)
         {

--- a/src/NativePacketParser.cpp
+++ b/src/NativePacketParser.cpp
@@ -19,33 +19,81 @@ uint32_t rd32(const unsigned char* p)
     return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16) |
            (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
 }
+uint32_t rdLe32(const unsigned char* p)
+{
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// 小写十六进制（1/2 字节 → "10" / "8001"）
+std::string hex2(uint8_t b)
+{
+    static const char* digits = "0123456789abcdef";
+    char buf[3];
+    buf[0] = digits[b >> 4];
+    buf[1] = digits[b & 0x0F];
+    buf[2] = '\0';
+    return std::string(buf);
+}
 
 std::string macToStr(const unsigned char* p)
 {
+    static const char* d = "0123456789abcdef";
     char buf[18];
-    std::snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x", p[0], p[1], p[2], p[3],
-                  p[4], p[5]);
-    return std::string(buf);
+    int  o = 0;
+    for (int i = 0; i < 6; ++i)
+    {
+        if (i)
+            buf[o++] = ':';
+        buf[o++] = d[p[i] >> 4];
+        buf[o++] = d[p[i] & 0x0F];
+    }
+    return std::string(buf, static_cast<size_t>(o));
 }
 
 std::string ipv4ToStr(const unsigned char* p)
 {
     char buf[16];
-    std::snprintf(buf, sizeof(buf), "%u.%u.%u.%u", p[0], p[1], p[2], p[3]);
-    return std::string(buf);
+    int  o = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        if (i)
+            buf[o++] = '.';
+        unsigned v = p[i];
+        if (v >= 100)
+        {
+            buf[o++] = static_cast<char>('0' + v / 100);
+            v %= 100;
+            buf[o++] = static_cast<char>('0' + v / 10);
+            buf[o++] = static_cast<char>('0' + v % 10);
+        }
+        else if (v >= 10)
+        {
+            buf[o++] = static_cast<char>('0' + v / 10);
+            buf[o++] = static_cast<char>('0' + v % 10);
+        }
+        else
+            buf[o++] = static_cast<char>('0' + v);
+    }
+    return std::string(buf, static_cast<size_t>(o));
 }
 
 std::string ipv6ToStr(const unsigned char* p)
 {
-    char buf[40];
-    int  pos = 0;
+    static const char* d = "0123456789abcdef";
+    char                buf[40];
+    int                 o = 0;
     for (int i = 0; i < 8; ++i)
     {
-        pos += std::snprintf(buf + pos, sizeof(buf) - pos, "%02x%02x", p[i * 2], p[i * 2 + 1]);
-        if (i < 7)
-            buf[pos++] = ':';
+        if (i)
+            buf[o++] = ':';
+        uint16_t g = rd16(p + i * 2);
+        buf[o++]   = d[(g >> 12) & 0xF];
+        buf[o++]   = d[(g >> 8) & 0xF];
+        buf[o++]   = d[(g >> 4) & 0xF];
+        buf[o++]   = d[g & 0xF];
     }
-    return std::string(buf);
+    return std::string(buf, static_cast<size_t>(o));
 }
 
 // TCP flags → "[SYN, ACK]" 写入定长栈缓冲（无 flag 写空串），省去每包临时 std::string。
@@ -71,7 +119,7 @@ void tcpFlagsToBuf(char* out, size_t n, unsigned char flags)
                                                   f.name));
         first = false;
     }
-    if (first) // 一个 flag 都没有
+    if (first)
     {
         out[0] = '\0';
         return;
@@ -96,12 +144,14 @@ const char* serviceForPort(uint16_t port, bool udp)
         if (port == 137 || port == 138) return "NetBIOS";
         if (port == 5353) return "MDNS";
         if (port == 1900) return "SSDP";
+        if (port == 13400) return "DoIP"; // ISO 13400-2 车辆发现（UDP）
         if (port == 443) return "QUIC";
     }
     else
     {
         if (port == 80 || port == 8080) return "HTTP";
         if (port == 443 || port == 8443) return "TLS";
+        if (port == 13400) return "DoIP"; // ISO 13400-2 诊断 over IP（Tester→ECU）
         if (port == 22) return "SSH";
         if (port == 53) return "TCP-DNS";
         if (port == 21) return "FTP";
@@ -116,34 +166,57 @@ const char* serviceForPort(uint16_t port, bool udp)
 }
 
 // ---- DNS 辅助 ----
-// 解析 DNS 名字（标签序列；遇压缩指针 0xC0 停止并返回消费字节数）
-std::string dnsNameAt(const unsigned char* p, uint32_t avail, uint32_t& consumed)
+// 解析 DNS 名字（标签序列；遇压缩指针 0xC0xx（RFC 1035 §4.1.4）跟随跳转，在整份报文 base 内查找目标标签）。
+// offset：名字在 base 内的起始偏移；consumed：本次调用（含跟随的指针）在「起始位置」处占用的字节数
+// （只统计第一段——即指针本身 2 字节，或未遇指针前的标签序列——不含跳转目标处的字节，供上层推进偏移量用）。
+// 只允许向后跳（ptr < 当前访问过的最小偏移）并限制跳转次数，防止构造恶意报文时形成死循环。
+std::string dnsNameAt(const unsigned char* base, uint32_t totalLen, uint32_t offset,
+                      uint32_t& consumed)
 {
     std::string name;
-    uint32_t    pos = 0;
-    while (pos < avail)
+    uint32_t    pos          = offset;
+    uint32_t    firstConsumed = 0;
+    bool        gotFirst     = false;
+    int         jumps        = 0;
+    for (;;)
     {
-        uint8_t len = p[pos];
+        if (pos >= totalLen)
+            break;
+        uint8_t len = base[pos];
         if (len == 0)
         {
-            ++pos;
+            if (!gotFirst)
+            {
+                firstConsumed = pos + 1 - offset;
+                gotFirst      = true;
+            }
             break;
         }
         if ((len & 0xC0) == 0xC0)
         {
-            pos += 2; // 压缩指针：不跟随
-            break;
+            if (pos + 1 >= totalLen || ++jumps > 32)
+                break;
+            uint32_t ptr = (static_cast<uint32_t>(len & 0x3F) << 8) | base[pos + 1];
+            if (!gotFirst)
+            {
+                firstConsumed = pos + 2 - offset;
+                gotFirst      = true;
+            }
+            if (ptr >= pos)
+                break; // 只允许向后跳（严格小于指针自身位置），防止自引用/循环；配合跳转次数上限兜底
+            pos = ptr;
+            continue;
         }
         ++pos;
-        if (pos + len > avail)
+        if (pos + len > totalLen)
             break;
         if (!name.empty())
             name += '.';
         for (uint32_t i = 0; i < len; ++i)
-            name += static_cast<char>(p[pos + i]);
+            name += static_cast<char>(base[pos + i]);
         pos += len;
     }
-    consumed = pos;
+    consumed = gotFirst ? firstConsumed : (pos - offset);
     return name;
 }
 
@@ -176,7 +249,7 @@ std::string dnsFirstQuestion(const unsigned char* payload, uint32_t len, uint16_
         return std::string();
     uint32_t off = 12;
     uint32_t consumed = 0;
-    std::string name = dnsNameAt(payload + 12, len - 12, consumed);
+    std::string name = dnsNameAt(payload, len, off, consumed);
     off += consumed;
     if (off + 4 <= len)
         qtype = rd16(payload + off);
@@ -195,22 +268,20 @@ std::string dnsAnswerSummary(const unsigned char* payload, uint32_t len)
     if (an == 0)
         return out;
     uint32_t off = 12;
-    // 跳过 questions
     for (uint16_t i = 0; i < qd; ++i)
     {
         if (off >= len)
             return out;
         uint32_t consumed = 0;
-        dnsNameAt(payload + off, len - off, consumed);
+        dnsNameAt(payload, len, off, consumed);
         off += consumed + 4; // qtype + qclass
     }
-    // 解析 answers
     for (uint16_t i = 0; i < an && i < anMax; ++i)
     {
         if (off + 10 > len)
             break;
         uint32_t consumed = 0;
-        dnsNameAt(payload + off, len - off, consumed);
+        dnsNameAt(payload, len, off, consumed);
         off += consumed;
         if (off + 10 > len)
             break;
@@ -231,8 +302,9 @@ std::string dnsAnswerSummary(const unsigned char* payload, uint32_t len)
         }
         else if ((type == 12 || type == 5 || type == 2) && rdlen > 0) // PTR/CNAME/NS
         {
+            // 传入整份报文 base + rdata 的绝对偏移（而非局部切片），使压缩指针能跟随到报文其它位置。
             uint32_t c = 0;
-            std::string n = dnsNameAt(rdata, rdlen, c);
+            std::string n = dnsNameAt(payload, len, off + 10, c);
             std::snprintf(buf, sizeof(buf), "%s %s", dnsTypeName(type), n.c_str());
         }
         else if (type == 16 && rdlen > 0) // TXT
@@ -255,7 +327,6 @@ std::string dnsAnswerSummary(const unsigned char* payload, uint32_t len)
     return out;
 }
 
-// DNS 报文 → info 摘要（查询 + 响应回答）
 std::string dnsInfo(const unsigned char* payload, uint32_t len, ProtocolDetail& detail)
 {
     if (len < 12)
@@ -328,7 +399,6 @@ void parseHttp(const unsigned char* payload, uint32_t len, Packet& packet, Proto
         detail.httpMethod  = tok1;
         detail.httpUri     = tok2;
         detail.httpVersion = tok3;
-        // 找 Host 头（前几行内）
         const unsigned char* p = payload;
         const unsigned char* end = payload + len;
         for (int i = 0; i < 20 && p < end; ++i)
@@ -377,12 +447,13 @@ void parseTls(const unsigned char* payload, uint32_t len, Packet& packet, Protoc
     if (version)
         detail.tlsVersion = version;
 
+    const char* recordType = "Unknown"; // 保证 detail.tls 为真时 tlsType 全程非空
     if (rtype == 0x16) // Handshake
     {
         if (len < 6)
             return;
         unsigned char hsType = payload[5];
-        const char*   hsName = nullptr;
+        const char*   hsName = "Handshake";
         switch (hsType)
         {
         case 1: hsName = "Client Hello"; break;
@@ -394,10 +465,9 @@ void parseTls(const unsigned char* payload, uint32_t len, Packet& packet, Protoc
         case 15: hsName = "Certificate Verify"; break;
         case 16: hsName = "Client Key Exchange"; break;
         case 20: hsName = "Finished"; break;
-        default: hsName = "Handshake"; break;
+        default: break;
         }
-        detail.tlsType = hsName;
-        // ClientHello（type 1）里提取 SNI
+        recordType = hsName;
             if (hsType == 1 && len >= 12)
             {
                 // body: version(2) random(32) sidLen(1)+sid cipherLen(2)+ciphers compLen(1)+comp extLen(2)+ext
@@ -453,23 +523,23 @@ void parseTls(const unsigned char* payload, uint32_t len, Packet& packet, Protoc
         }
     else if (rtype == 0x17)
     {
-        detail.tlsType = "Application Data";
+        recordType = "Application Data";
     }
     else if (rtype == 0x15)
     {
-        detail.tlsType = "Alert";
+        recordType = "Alert";
     }
     else if (rtype == 0x14)
     {
-        detail.tlsType = "Change Cipher Spec";
+        recordType = "Change Cipher Spec";
     }
+    detail.tlsType = recordType;
     char buf[128];
     if (!detail.tlsSni.empty())
-        std::snprintf(buf, sizeof(buf), "%s, %s, SNI=%s", detail.tlsType.c_str(),
-                      version ? version : "TLS", detail.tlsSni.c_str());
+        std::snprintf(buf, sizeof(buf), "%s, %s, SNI=%s", recordType, version ? version : "TLS",
+                      detail.tlsSni.c_str());
     else
-        std::snprintf(buf, sizeof(buf), "%s, %s", detail.tlsType.c_str(),
-                      version ? version : "TLS");
+        std::snprintf(buf, sizeof(buf), "%s, %s", recordType, version ? version : "TLS");
     packet.info = buf;
 }
 
@@ -548,6 +618,382 @@ void parseNtp(const unsigned char* payload, uint32_t len, Packet& packet, Protoc
     packet.info    = buf;
 }
 
+// ---- SSH（RFC 4253 §4.2）----
+// 版本交换阶段以明文单行 banner 开始："SSH-protoversion-softwareversion[ comments]\r\n"（上限 255 字节）。
+// 交换完成后转入二进制协议且通常加密，本引擎不解密，只识别这条 banner 行。
+void parseSsh(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    detail.ssh = true;
+    if (len >= 4 && std::memcmp(payload, "SSH-", 4) == 0)
+    {
+        uint32_t scanLen = len > 255 ? 255 : len;
+        const unsigned char* nl = static_cast<const unsigned char*>(
+            std::memchr(payload, '\n', scanLen));
+        uint32_t lineLen = nl ? static_cast<uint32_t>(nl - payload) : scanLen;
+        if (lineLen > 0 && payload[lineLen - 1] == '\r')
+            --lineLen;
+        detail.sshVersion.assign(reinterpret_cast<const char*>(payload), lineLen);
+        packet.info = "Protocol: " + detail.sshVersion;
+        return;
+    }
+    char buf[48];
+    std::snprintf(buf, sizeof(buf), "Encrypted Packet (len=%u)", len);
+    packet.info = buf;
+}
+
+// ---- DoIP（ISO 13400-2）/ UDS（ISO 14229-1）/ CAN ----
+const char* doipPayloadTypeName(uint16_t t)
+{
+    switch (t)
+    {
+    case 0x0000: return "Generic DoIP header negative acknowledge";
+    case 0x0001: return "Vehicle identification request";
+    case 0x0002: return "Vehicle identification request with EID";
+    case 0x0003: return "Vehicle identification request with VIN";
+    case 0x0004: return "Vehicle identification response";
+    case 0x0005: return "Routing activation request";
+    case 0x0006: return "Routing activation response";
+    case 0x0007: return "Alive check request";
+    case 0x0008: return "Alive check response";
+    case 0x4001: return "DoIP entity status request";
+    case 0x4002: return "DoIP entity status response";
+    case 0x4003: return "Diagnostic power mode information request";
+    case 0x4004: return "Diagnostic power mode information response";
+    case 0x8001: return "Diagnostic message";
+    case 0x8002: return "Diagnostic message positive acknowledgement";
+    case 0x8003: return "Diagnostic message negative acknowledgement";
+    case 0x8004: return "Diagnostic message (ISO 13400-2:2016)";
+    default: return "Unknown";
+    }
+}
+
+const char* udsServiceName(uint8_t sid)
+{
+    switch (sid)
+    {
+    case 0x10: return "DiagnosticSessionControl";
+    case 0x11: return "ECUReset";
+    case 0x14: return "ClearDiagnosticInformation";
+    case 0x19: return "ReadDTCInformation";
+    case 0x22: return "ReadDataByIdentifier";
+    case 0x23: return "ReadMemoryByAddress";
+    case 0x24: return "ReadScalingDataByIdentifier";
+    case 0x27: return "SecurityAccess";
+    case 0x28: return "CommunicationControl";
+    case 0x29: return "Authentication";
+    case 0x2A: return "ReadDataByPeriodicIdentifier";
+    case 0x2C: return "DynamicallyDefineDataIdentifier";
+    case 0x2E: return "WriteDataByIdentifier";
+    case 0x2F: return "InputOutputControlByIdentifier";
+    case 0x31: return "RoutineControl";
+    case 0x34: return "RequestDownload";
+    case 0x35: return "RequestUpload";
+    case 0x36: return "TransferData";
+    case 0x37: return "RequestTransferExit";
+    case 0x38: return "RequestFileTransfer";
+    case 0x3D: return "WriteMemoryByAddress";
+    case 0x3E: return "TesterPresent";
+    case 0x83: return "AccessTimingParameter";
+    case 0x84: return "SecuredDataTransmission";
+    case 0x85: return "ControlDTCSetting";
+    case 0x86: return "ResponseOnEvent";
+    case 0x87: return "LinkControl";
+    default: return "Unknown";
+    }
+}
+
+const char* udsNrcName(uint8_t nrc)
+{
+    switch (nrc)
+    {
+    case 0x00: return "No error";
+    case 0x10: return "General reject";
+    case 0x11: return "Service not supported";
+    case 0x12: return "Sub-function not supported";
+    case 0x13: return "Incorrect message length or invalid format";
+    case 0x14: return "Response too long";
+    case 0x21: return "Busy repeat request";
+    case 0x22: return "Conditions not correct";
+    case 0x24: return "Request sequence error";
+    case 0x25: return "No response from subnet component";
+    case 0x26: return "Failure prevents execution of requested action";
+    case 0x31: return "Request out of range";
+    case 0x33: return "Security access denied";
+    case 0x34: return "Authentication failed";
+    case 0x35: return "Invalid key";
+    case 0x36: return "Exceeded number of attempts";
+    case 0x37: return "Required time delay not expired";
+    case 0x70: return "Upload/download not accepted";
+    case 0x71: return "Transfer data suspended";
+    case 0x72: return "General programming failure";
+    case 0x73: return "Wrong block sequence counter";
+    case 0x78: return "Request correctly received - response pending";
+    case 0x7E: return "Sub-function not supported in active session";
+    case 0x7F: return "Service not supported in active session";
+    case 0x81: return "Voltage too high";
+    case 0x82: return "Voltage too low";
+    default: return "Unknown";
+    }
+}
+
+// UDS（ISO 14229-1）负载：首字节 SID。请求 SID 0x10~0x87；正响应 = SID+0x40；
+// 负响应 SID=0x7F（后随原 SID 与 NRC）。
+void parseUds(const unsigned char* p, uint32_t len, ProtocolDetail& detail)
+{
+    if (!p || len < 1)
+        return;
+    uint8_t sid = p[0];
+    detail.uds  = true;
+    char    buf[96];
+    if (sid == 0x7F)
+    {
+        detail.udsResponse = true;
+        if (len >= 2)
+        {
+            std::snprintf(buf, sizeof(buf), "Negative response: %s (0x%02x)", udsServiceName(p[1]),
+                          p[1]);
+            detail.udsService = buf;
+        }
+        else
+            detail.udsService = "Negative response";
+        if (len >= 3)
+        {
+            std::snprintf(buf, sizeof(buf), "%s (0x%02x)", udsNrcName(p[2]), p[2]);
+            detail.udsNrc = buf;
+        }
+        return;
+    }
+    if ((sid & 0x40) != 0)
+    {
+        detail.udsResponse = true;
+        uint8_t reqSid      = static_cast<uint8_t>(sid & 0xBF);
+        std::snprintf(buf, sizeof(buf), "Positive response: %s (0x%02x)", udsServiceName(reqSid),
+                      reqSid);
+        detail.udsService = buf;
+        return;
+    }
+    std::snprintf(buf, sizeof(buf), "%s (0x%02x)", udsServiceName(sid), sid);
+    detail.udsService = buf;
+}
+
+// 已知 UDS 服务 SID（请求/正响应/负响应），用于判定 CAN 数据区是否为 UDS 负载（降低误报）。
+bool isKnownUdsSid(uint8_t b)
+{
+    if (b == 0x7F)
+        return true;
+    if ((b & 0x40) != 0)
+        b = static_cast<uint8_t>(b & 0xBF); // 正响应：回退到请求 SID
+    switch (b)
+    {
+    case 0x10: case 0x11: case 0x14: case 0x19: case 0x22: case 0x23: case 0x24:
+    case 0x27: case 0x28: case 0x29: case 0x2A: case 0x2C: case 0x2E: case 0x2F:
+    case 0x31: case 0x34: case 0x35: case 0x36: case 0x37: case 0x38: case 0x3D:
+    case 0x3E: case 0x83: case 0x84: case 0x85: case 0x86: case 0x87:
+        return true;
+    default: return false;
+    }
+}
+
+// DoIP（ISO 13400-2）帧头：ver(1) invVer(1) payloadType(2) payloadLen(4)，网络字节序。
+// 诊断消息（0x8001/0x8004）负载 = 源地址(2) + 目标地址(2) + UDS。
+void parseDoip(const unsigned char* payload, uint32_t len, Packet& packet, ProtocolDetail& detail)
+{
+    if (!payload || len < 8)
+        return;
+    uint8_t  ver    = payload[0];
+    uint8_t  invVer = payload[1];
+    uint16_t type   = rd16(payload + 2);
+    uint32_t plen   = rd32(payload + 4);
+    if (ver + invVer != 0xFF) // 版本 + 反码校验（0x02+0xFD / 0x03+0xFC）
+        return;
+    detail.doip      = true;
+    detail.doipType  = type;
+    detail.doipVersion = (ver == 0x02) ? "ISO 13400-2:2012"
+                         : (ver == 0x03) ? "ISO 13400-2:2016"
+                                         : "v" + std::to_string(ver);
+    if (plen > len - 8)
+        plen = len - 8;
+    const unsigned char* body = payload + 8;
+
+    if (type == 0x8001 || type == 0x8004) // 诊断消息（源/目标地址 + UDS）
+    {
+        uint32_t udsOff = (plen >= 4) ? 4 : 0;
+        if (plen > udsOff)
+            parseUds(body + udsOff, plen - udsOff, detail);
+    }
+    else if (type == 0x8002 && plen >= 1) // 诊断消息 ACK：ackCode(1) + ...
+    {
+        detail.doipDesc = (body[0] == 0x00) ? "Diagnostic message ACK (positive)"
+                                            : "Diagnostic message ACK (negative)";
+    }
+
+    char buf[200];
+    const char* name = doipPayloadTypeName(type);
+    if (detail.uds)
+    {
+        if (detail.udsNrc.empty())
+            std::snprintf(buf, sizeof(buf), "%s, %s", name, detail.udsService.c_str());
+        else
+            std::snprintf(buf, sizeof(buf), "%s, %s, NRC %s", name, detail.udsService.c_str(),
+                          detail.udsNrc.c_str());
+    }
+    else
+        std::snprintf(buf, sizeof(buf), "%s (type=0x%04x, len=%u)", name, type, plen);
+    packet.info     = buf;
+    packet.protocol = detail.uds ? "UDS" : "DoIP";
+    packet.is_doip  = true;
+}
+
+std::string canDataHex(const unsigned char* d, uint32_t n)
+{
+    std::string s;
+    uint32_t show = n > 8 ? 8 : n;
+    for (uint32_t i = 0; i < show; ++i)
+    {
+        if (i)
+            s += ' ';
+        s += hex2(d[i]);
+    }
+    if (n > show)
+        s += " ...";
+    return s;
+}
+
+// 提取 CAN/CAN FD 帧的 ID 与数据区（不含 ISO-TP/UDS 语义），parseCan 与 feedCanFrame 共用。链路布局：
+//   DLT 227（SocketCAN）：8 字节头 can_id(4, LE) + flags/len(4) + data（偏移 8 起）。
+//   DLT 228（原始 CAN）：4 字节 can_id(LE，高 3 位 EFF/RTR/ERR) + 数据（经典 ≤8）。
+//   DLT 229（原始 CAN FD）：同 228，数据可达 64 字节。
+// can_id 高 3 位标志：0x80000000=EFF（扩展帧） 0x40000000=RTR 0x20000000=ERR。
+bool extractCanPayload(const unsigned char* data, uint32_t len, int linkType, uint32_t& canId,
+                       bool& extended, const unsigned char*& dptr, uint32_t& dlen)
+{
+    if (!data || len < 4)
+        return false;
+    if (linkType == 227)
+    {
+        if (len < 8)
+            return false;
+        uint32_t raw = rdLe32(data);
+        canId        = raw & 0x1FFFFFFF;
+        extended     = (raw & 0x80000000) != 0;
+        dptr = data + 8;
+        dlen = len - 8;
+    }
+    else // DLT 228 / 229
+    {
+        uint32_t raw = rdLe32(data);
+        canId        = raw & 0x1FFFFFFF;
+        extended     = (raw & 0x80000000) != 0;
+        uint32_t maxD = (linkType == 229) ? 64 : 8;
+        dptr = data + 4;
+        dlen = len - 4;
+        if (dlen > maxD)
+            dlen = maxD;
+    }
+    return true;
+}
+
+// CAN 帧解析（含 ISO-TP 单帧/多帧解包后识别 UDS 负载）。
+// isoTp：非空时用于 FF/CF/FC 跨帧重组；为空时仍能识别帧类型，但不会累积/完成多帧重组。
+void parseCan(const unsigned char* data, uint32_t len, int linkType, Packet& packet,
+              ProtocolDetail& detail, IsoTpReassembler* isoTp)
+{
+    uint32_t canId = 0;
+    bool     extended = false;
+    const unsigned char* dptr = nullptr;
+    uint32_t              dlen = 0;
+    if (!extractCanPayload(data, len, linkType, canId, extended, dptr, dlen))
+        return;
+    detail.can          = true;
+    detail.canId        = canId;
+    detail.canExtended  = extended;
+    packet.can_id       = canId;
+
+    uint32_t    dlc  = dlen;
+    const char* kind = "CAN";
+    if (linkType == 227)
+    {
+        unsigned char flags = data[4];
+        bool          isFd  = (flags & 0x80) != 0; // CANFD_FDF
+        dlc = isFd ? data[5] : (flags & 0x0F);
+        if (dlc > dlen)
+            dlc = dlen;
+        if (isFd)
+        {
+            bool brs = (flags & 0x01) != 0, esi = (flags & 0x02) != 0;
+            kind = (brs && esi) ? "CAN FD BRS ESI" : brs ? "CAN FD BRS" : esi ? "CAN FD ESI"
+                                                                              : "CAN FD";
+        }
+    }
+    else if (linkType == 229)
+        kind = "CAN FD";
+    detail.canKind = kind;
+
+    // ISO-TP（ISO 15765-2）与直接 UDS 的判定天然存在歧义：ISO-TP 的 PCI 字节（FF=0x1x/CF=0x2x/
+    // FC=0x3x）与 UDS SID 空间（几乎覆盖 0x10~0x3E）完全重叠，单看首字节无法可靠区分。这里沿用
+    // 既有的「长度前缀」启发式——先按 SF 语义尝试解出一个已知 SID；命中则认定是不走 ISO-TP 封装、
+    // 直接携带 UDS 的帧（覆盖原 ParsesRawCan/ParsesUdsOverCanSingleFrame 两类用例，逻辑不变）。
+    // 只有这个启发式没命中时，才按 PCI 高 4 位识别 FF/CF/FC 做跨帧重组——保证像 FF 的 0x10 这种
+    // 「PCI 字节恰好等于某个 SID」的合法 ISO-TP 帧不会被误判为直接 UDS。
+    uint8_t pci = (dlen >= 1) ? static_cast<uint8_t>(dptr[0] & 0xF0) : 0xFFu;
+    uint32_t udsOff = 0, udsLen = dlen;
+    if (dlen >= 2 && (dptr[0] & 0x0F) <= dlen - 1)
+    {
+        udsOff = 1;
+        udsLen = dptr[0] & 0x0F;
+    }
+    if (udsLen >= 1 && isKnownUdsSid(dptr[udsOff]))
+    {
+        parseUds(dptr + udsOff, udsLen, detail);
+    }
+    else if (pci == 0x10 || pci == 0x20 || pci == 0x30) // FF/CF/FC：跨帧重组
+    {
+        detail.isoTpFrame = true;
+        IsoTpReassembler local; // 无重组器时的兜底：仅无状态识别帧类型，不会误报 completed
+        IsoTpReassembler::Result r = isoTp ? isoTp->feed(canId, dptr, dlen)
+                                            : local.feed(canId, dptr, dlen);
+        detail.isoTpKind = (pci == 0x10) ? "First Frame"
+                          : (pci == 0x20) ? "Consecutive Frame"
+                                          : "Flow Control";
+        detail.isoTpSeq      = (pci == 0x20) ? static_cast<uint16_t>(dptr[0] & 0x0F) : 0;
+        detail.isoTpTotalLen = r.totalLen;
+        if (r.completed && !r.payload.empty() && isKnownUdsSid(r.payload[0]))
+            parseUds(r.payload.data(), static_cast<uint32_t>(r.payload.size()), detail);
+    }
+
+    char buf[160];
+    if (detail.uds)
+    {
+        std::snprintf(buf, sizeof(buf), "%s 0x%03x, %s", detail.canKind, detail.canId,
+                      detail.udsService.c_str());
+        packet.protocol = "UDS";
+    }
+    else if (detail.isoTpFrame)
+    {
+        if (pci == 0x10)
+            std::snprintf(buf, sizeof(buf), "%s 0x%03x ISO-TP First Frame, Len=%u",
+                          detail.canKind, detail.canId, detail.isoTpTotalLen);
+        else if (pci == 0x20)
+            std::snprintf(buf, sizeof(buf), "%s 0x%03x ISO-TP Consecutive Frame, Seq=%u",
+                          detail.canKind, detail.canId, detail.isoTpSeq);
+        else
+            std::snprintf(buf, sizeof(buf), "%s 0x%03x ISO-TP Flow Control", detail.canKind,
+                          detail.canId);
+        packet.protocol = detail.canKind;
+    }
+    else
+    {
+        if (detail.canExtended)
+            std::snprintf(buf, sizeof(buf), "%s 0x%08x DLC=%u %s", detail.canKind, detail.canId,
+                          dlc, canDataHex(dptr, dlen).c_str());
+        else
+            std::snprintf(buf, sizeof(buf), "%s 0x%03x DLC=%u %s", detail.canKind, detail.canId,
+                          dlc, canDataHex(dptr, dlen).c_str());
+        packet.protocol = detail.canKind;
+    }
+    packet.info = buf;
+}
+
 // ---- TCP/UDP ----
 void parseTcp(const unsigned char* data, uint32_t len, Packet& packet, ProtocolDetail& detail)
 {
@@ -570,14 +1016,17 @@ void parseTcp(const unsigned char* data, uint32_t len, Packet& packet, ProtocolD
     uint32_t      tcpLen = (len >= 12) ? ((data[12] >> 4) * 4) : 20;
     uint32_t      appLen = (len > tcpLen) ? (len - tcpLen) : 0;
 
-    // 应用层解析（载荷非空且是已识别服务）
     const unsigned char* app = data + tcpLen;
     if (appLen > 0 && packet.protocol == "HTTP")
         parseHttp(app, appLen, packet, detail);
     else if (appLen > 0 && packet.protocol == "TLS")
         parseTls(app, appLen, packet, detail);
+    else if (appLen > 0 && packet.protocol == "DoIP")
+        parseDoip(app, appLen, packet, detail);
+    else if (appLen > 0 && packet.protocol == "SSH")
+        parseSsh(app, appLen, packet, detail);
 
-    if (detail.http || detail.tls)
+    if (detail.http || detail.tls || detail.doip || detail.ssh)
         return; // 应用层已填 info
 
     char flagsBuf[40];
@@ -627,6 +1076,11 @@ void parseUdp(const unsigned char* data, uint32_t len, Packet& packet, ProtocolD
     if (packet.protocol == "NTP" && appLen > 0)
     {
         parseNtp(app, appLen, packet, detail);
+        return;
+    }
+    if (packet.protocol == "DoIP" && appLen > 0)
+    {
+        parseDoip(app, appLen, packet, detail);
         return;
     }
     char buf[48];
@@ -711,7 +1165,6 @@ void parseArp(const unsigned char* data, uint32_t len, Packet& packet)
     }
 }
 
-// 解析 IPv4（含分片信息）
 bool parseIpv4(const unsigned char* data, uint32_t len, Packet& packet, uint8_t& proto,
                const unsigned char*& payload, uint32_t& payloadLen, ProtocolDetail& detail)
 {
@@ -736,7 +1189,7 @@ bool parseIpv4(const unsigned char* data, uint32_t len, Packet& packet, uint8_t&
 }
 
 bool parseIpv6(const unsigned char* data, uint32_t len, Packet& packet, uint8_t& proto,
-               const unsigned char*& payload, uint32_t& payloadLen)
+               const unsigned char*& payload, uint32_t& payloadLen, ProtocolDetail& detail)
 {
     if (len < 40)
         return false;
@@ -754,10 +1207,14 @@ bool parseIpv6(const unsigned char* data, uint32_t len, Packet& packet, uint8_t&
             break;
         uint8_t next  = data[off];
         uint8_t hlen8 = data[off + 1];
-        if (proto == 44)
+        if (proto == 44) // Fragment Header：next(1) reserved(1) fragOffset+flags(2) id(4)
         {
             if (off + 8 > len)
                 break;
+            uint16_t fragField = rd16(data + off + 2);
+            detail.fragMore     = (fragField & 0x0001) != 0;
+            detail.fragOffset   = static_cast<uint16_t>((fragField & 0xFFF8));
+            detail.ipFragmented = detail.fragOffset != 0 || detail.fragMore;
             off += 8;
         }
         else if (proto == 51)
@@ -785,7 +1242,6 @@ bool parseIpv6(const unsigned char* data, uint32_t len, Packet& packet, uint8_t&
     return true;
 }
 
-// 以太网帧解析
 bool parseEthernet(const unsigned char* data, uint32_t len, Packet& packet,
                    const unsigned char*& payload, uint32_t& payloadLen, uint16_t& ethertype)
 {
@@ -847,7 +1303,7 @@ bool dispatchByEtherType(uint16_t ethertype, const unsigned char* payload, uint3
     if (ethertype == 0x86DD)
     {
         uint8_t proto = 0;
-        if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen))
+        if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen, detail))
             return false;
         if (proto == 6)
             parseTcp(payload, payloadLen, packet, detail);
@@ -892,11 +1348,20 @@ bool parseSll(const unsigned char* data, uint32_t len, bool v2, Packet& packet,
     return dispatchByEtherType(ethertype, data + hdr, len - hdr, packet, detail);
 }
 
-// 主解析：填充 Packet + ProtocolDetail
 bool parseFrameCtx(const unsigned char* data, uint32_t len, int linkType, Packet& packet,
-                   ProtocolDetail& detail)
+                   ProtocolDetail& detail, IsoTpReassembler* isoTp)
 {
-    if (!data || len < 14)
+    if (!data || len < 4)
+        return false;
+
+    // CAN 链路（SocketCAN 227 / 原始 CAN 228 / CAN FD 229）：帧长可小于以太网最小 14 字节，提前分派
+    if (linkType == 227 || linkType == 228 || linkType == 229)
+    {
+        parseCan(data, len, linkType, packet, detail, isoTp);
+        return true;
+    }
+
+    if (len < 14)
         return false;
 
     // NULL/Loopback 链路（BSD lo 接口）
@@ -934,7 +1399,7 @@ bool parseFrameCtx(const unsigned char* data, uint32_t len, int linkType, Packet
         if (family == 30 || family == 24)
         {
             uint8_t proto = 0;
-            if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen))
+            if (!parseIpv6(payload, payloadLen, packet, proto, payload, payloadLen, detail))
                 return false;
             if (proto == 6)
                 parseTcp(payload, payloadLen, packet, detail);
@@ -973,10 +1438,73 @@ bool available()
     return true;
 }
 
-bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType)
+IsoTpReassembler::Result IsoTpReassembler::feed(uint32_t canId, const unsigned char* data,
+                                                uint32_t len)
+{
+    Result r;
+    if (!data || len < 1)
+        return r;
+    uint8_t pci = static_cast<uint8_t>(data[0] & 0xF0);
+    if (pci == 0x10) // First Frame：低 4 位 + 下一字节 = 12 位总长度
+    {
+        if (len < 2)
+            return r;
+        r.kind     = kFirstFrame;
+        r.totalLen = static_cast<uint16_t>(((data[0] & 0x0F) << 8) | data[1]);
+        Session& s = sessions_[canId]; // 新首帧覆盖同 ID 上未完成的旧会话
+        s          = Session();
+        s.expectedLen = r.totalLen;
+        uint32_t avail = len - 2;
+        uint32_t take  = avail < s.expectedLen ? avail : s.expectedLen;
+        s.buf.assign(data + 2, data + 2 + take);
+        s.nextSeq = 1;
+    }
+    else if (pci == 0x20) // Consecutive Frame
+    {
+        r.kind = kConsecutive;
+        r.seq  = data[0] & 0x0F;
+        auto it = sessions_.find(canId);
+        if (it == sessions_.end())
+            return r; // 没有对应的首帧：孤立 CF，忽略（不崩溃）
+        Session& s = it->second;
+        uint32_t remain = s.expectedLen > s.buf.size()
+                              ? s.expectedLen - static_cast<uint32_t>(s.buf.size())
+                              : 0;
+        uint32_t avail = len - 1;
+        uint32_t take  = avail < remain ? avail : remain;
+        s.buf.insert(s.buf.end(), data + 1, data + 1 + take);
+        s.nextSeq = static_cast<uint8_t>((s.nextSeq + 1) & 0x0F);
+        if (s.buf.size() >= s.expectedLen)
+        {
+            r.completed = true;
+            r.payload   = s.buf;
+            sessions_.erase(it);
+        }
+    }
+    else if (pci == 0x30)
+    {
+        r.kind = kFlowControl; // 流控帧不携带负载，不进入会话状态
+    }
+    return r;
+}
+
+void feedCanFrame(const unsigned char* data, uint32_t len, int linkType, IsoTpReassembler& isoTp)
+{
+    uint32_t canId = 0;
+    bool     extended = false;
+    const unsigned char* dptr = nullptr;
+    uint32_t              dlen = 0;
+    if (!extractCanPayload(data, len, linkType, canId, extended, dptr, dlen))
+        return;
+    if (dlen >= 1)
+        isoTp.feed(canId, dptr, dlen); // 仅预热重组状态；SF/FC 对重组器天然 no-op
+}
+
+bool parseFrame(const unsigned char* data, uint32_t len, Packet& packet, int linkType,
+                IsoTpReassembler* isoTp)
 {
     ProtocolDetail detail;
-    return parseFrameCtx(data, len, linkType, packet, detail);
+    return parseFrameCtx(data, len, linkType, packet, detail, isoTp);
 }
 
 // ---- 完整协议树 ----
@@ -997,18 +1525,17 @@ void addLeaf(const std::string& label, const std::string& value, DetailNode& roo
 } // namespace
 
 bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint32_t frameNumber,
-                     DetailNode& root)
+                     DetailNode& root, IsoTpReassembler* isoTp)
 {
     Packet p;
     ProtocolDetail detail;
-    if (!parseFrameCtx(data, len, linkType, p, detail))
+    if (!parseFrameCtx(data, len, linkType, p, detail, isoTp))
         return false;
     p.frame_number = frameNumber;
 
     root.label = "Frame " + std::to_string(frameNumber);
     char buf[128];
 
-    // Ethernet II / Null/Loopback
     DetailNode eth;
     if (!p.src_mac.empty())
     {
@@ -1044,8 +1571,30 @@ bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint
         root.children.push_back(ip);
     }
 
-    // 传输层
-    if (p.transport == "TCP" || p.transport == "UDP")
+    // CAN 层（SocketCAN / 原始 CAN / CAN FD 链路帧）
+    if (detail.can)
+    {
+        DetailNode cn;
+        cn.label = "Controller Area Network";
+        char cbuf[32];
+        if (detail.canExtended)
+            std::snprintf(cbuf, sizeof(cbuf), "0x%08x", detail.canId);
+        else
+            std::snprintf(cbuf, sizeof(cbuf), "0x%03x", detail.canId);
+        addChild(cn, "ID", cbuf);
+        addChild(cn, "Kind", detail.canKind);
+        if (detail.isoTpFrame && !detail.uds)
+        {
+            addChild(cn, "ISO-TP", detail.isoTpKind);
+            if (detail.isoTpKind[0] == 'F') // First Frame
+                addChild(cn, "Declared Length", std::to_string(detail.isoTpTotalLen));
+            else if (detail.isoTpKind[0] == 'C') // Consecutive Frame
+                addChild(cn, "Sequence", std::to_string(detail.isoTpSeq));
+        }
+        addChild(cn, "Info", p.info);
+        root.children.push_back(cn);
+    }
+    else if (p.transport == "TCP" || p.transport == "UDP")
     {
         DetailNode tr;
         tr.label = (p.transport == "TCP") ? "Transmission Control Protocol"
@@ -1075,7 +1624,36 @@ bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint
     }
 
     // 应用层分层
-    if (detail.http)
+    if (detail.doip)
+    {
+        DetailNode dp;
+        dp.label = "Diagnostic over IP";
+        addChild(dp, "Version", detail.doipVersion);
+        std::snprintf(buf, sizeof(buf), "%s (0x%04x)",
+                      detail.doipDesc ? detail.doipDesc : doipPayloadTypeName(detail.doipType),
+                      detail.doipType);
+        addChild(dp, "Payload Type", buf);
+        if (detail.uds)
+        {
+            DetailNode ud;
+            ud.label = "Unified Diagnostic Services";
+            addChild(ud, "Service", detail.udsService);
+            if (!detail.udsNrc.empty())
+                addChild(ud, "Negative Response Code", detail.udsNrc);
+            dp.children.push_back(ud);
+        }
+        root.children.push_back(dp);
+    }
+    else if (detail.uds) // CAN 负载上的 UDS（ISO-TP 单帧）
+    {
+        DetailNode ud;
+        ud.label = "Unified Diagnostic Services";
+        addChild(ud, "Service", detail.udsService);
+        if (!detail.udsNrc.empty())
+            addChild(ud, "Negative Response Code", detail.udsNrc);
+        root.children.push_back(ud);
+    }
+    else if (detail.http)
     {
         DetailNode hp;
         hp.label = "Hypertext Transfer Protocol";
@@ -1096,11 +1674,21 @@ bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint
         DetailNode tl;
         tl.label = "Transport Layer Security";
         addChild(tl, "Handshake", detail.tlsType);
-        if (!detail.tlsVersion.empty())
+        if (detail.tlsVersion)
             addChild(tl, "Version", detail.tlsVersion);
         if (!detail.tlsSni.empty())
             addChild(tl, "Server Name Indication", detail.tlsSni);
         root.children.push_back(tl);
+    }
+    else if (detail.ssh)
+    {
+        DetailNode sh;
+        sh.label = "SSH Protocol";
+        if (!detail.sshVersion.empty())
+            addChild(sh, "Protocol", detail.sshVersion);
+        else
+            addChild(sh, "Info", p.info);
+        root.children.push_back(sh);
     }
     else if (p.protocol == "DNS")
     {
@@ -1115,7 +1703,7 @@ bool buildDetailTree(const unsigned char* data, uint32_t len, int linkType, uint
     {
         DetailNode dh;
         dh.label = "Dynamic Host Configuration Protocol";
-        addChild(dh, "Message Type", detail.dhcpType);
+        addChild(dh, "Message Type", detail.dhcpType ? detail.dhcpType : "?");
         addChild(dh, "Info", p.info);
         root.children.push_back(dh);
     }
@@ -1314,6 +1902,11 @@ private:
             long        v  = std::strtol(value.c_str(), nullptr, 10);
             eq = [tp, v](const Packet& p) { return p.transport == tp && p.dst_port == v; };
         }
+        else if (field == "can.id") // 支持 0x 前缀十六进制或十进制
+        {
+            unsigned long v = std::strtoul(value.c_str(), nullptr, 0);
+            eq = [v](const Packet& p) { return p.can_id != 0 && p.can_id == v; };
+        }
         else
         {
             setErr("unsupported field '" + field + "'");
@@ -1341,6 +1934,11 @@ private:
         if (f == "ssh") return [](const Packet& p) { return p.protocol == "SSH"; };
         if (f == "dhcp") return [](const Packet& p) { return p.protocol == "DHCP"; };
         if (f == "ntp") return [](const Packet& p) { return p.protocol == "NTP"; };
+        if (f == "doip") return [](const Packet& p) { return p.is_doip; };
+        if (f == "uds") return [](const Packet& p) { return p.protocol == "UDS"; };
+        if (f == "can")
+            // 匹配 CAN / CAN FD / CAN FD BRS 等（canKind 前缀均为 "CAN"）
+            return [](const Packet& p) { return p.protocol.compare(0, 3, "CAN") == 0; };
         if (f == "ip") return [](const Packet& p) { return !p.src_ip.empty(); };
         if (f == "ipv6")
             return [](const Packet& p) { return p.src_ip.find(':') != std::string::npos; };

--- a/src/PcapAnalyzer.cpp
+++ b/src/PcapAnalyzer.cpp
@@ -141,7 +141,6 @@ bool PcapAnalyzer::streamPackets(
         }
         else
         {
-            // 记录本包偏移，再前移游标到下一包起始（包头 + 抓包长度）
             packet->file_offset = file_offset + sizeof(PacketHeader);
             file_offset         = file_offset + sizeof(PacketHeader) + packet->cap_len;
         }
@@ -309,7 +308,7 @@ bool PcapAnalyzer::getPacketHexData(uint32_t frameNumber, std::vector<unsigned c
 
 namespace
 {
-// 把管道里的全部字节读进字符串（tshark 单包 PDML 输出通常不大，一次读完最省事）。
+// tshark 单包 PDML 输出通常不大，一次读完最省事。
 std::string readPipeToString(FILE* pipe)
 {
     std::string out;
@@ -322,14 +321,14 @@ std::string readPipeToString(FILE* pipe)
     return out;
 }
 
-// 取属性值，取不到返回空串（rapidxml 的 first_attribute 可能为 nullptr）。
+// rapidxml 的 first_attribute 可能为 nullptr，需判空后再取值。
 std::string attr(rapidxml::xml_node<>* node, const char* name)
 {
     rapidxml::xml_attribute<>* a = node->first_attribute(name);
     return a ? std::string(a->value(), a->value_size()) : std::string();
 }
 
-// 把 PDML 的 <proto>/<field> 节点递归转成 DetailNode：label 用 showname 回退 name，value 用 show 回退 value。
+// PDML 字段命名约定：label 用 showname 回退 name，value 用 show 回退 value。
 DetailNode pdmlNodeToDetail(rapidxml::xml_node<>* node)
 {
     DetailNode d;
@@ -449,7 +448,6 @@ bool PcapAnalyzer::getFramesByDisplayFilter(const std::string&     displayFilter
     bool   sawError = false; // stderr 合并后，错误行以 "tshark:" 等前缀出现
     while (fgets(buffer, sizeof(buffer), pipe) != nullptr)
     {
-        // 每行一个帧号，可能带前后空白；空行跳过。
         std::string line(buffer);
         size_t      begin = line.find_first_not_of(" \t\r\n");
         if (begin == std::string::npos)

--- a/src/PcapFileReader.cpp
+++ b/src/PcapFileReader.cpp
@@ -38,7 +38,6 @@ bool PcapFileReader::readAt(uint64_t offset, uint32_t len, std::vector<unsigned 
     {
         return false;
     }
-    // 越界检查：避免读到文件尾之外的未定义内容
     if (offset > size_ || len > size_ - offset)
     {
         LOG_F(ERROR, "报文读取越界（偏移 %llu，长度 %u，文件大小 %llu）",
@@ -130,9 +129,10 @@ bool PcapFileReader::open(const std::string& path)
         return false;
     }
 
-    // readAt 是随机小读，内核默认顺序预读会白调相邻页；MADV_RANDOM 关掉预读，只调命中页。
-    // 提示失败不影响正确性（退回默认预读），忽略返回值。
-    ::posix_madvise(addr, static_cast<size_t>(st.st_size), POSIX_MADV_RANDOM);
+    // 主路径是 analyzeFile 对整份文件的一次顺序 viewAt 扫描（readAt 随机访问只在
+    // hex/详情树按需查询时偶发），MADV_SEQUENTIAL 让内核预读跟上顺序访问，减少缺页次数。
+    // 提示失败不影响正确性（退回默认策略），忽略返回值。
+    ::posix_madvise(addr, static_cast<size_t>(st.st_size), POSIX_MADV_SEQUENTIAL);
 
     fd_     = fd;
     mapped_ = addr;
@@ -146,7 +146,6 @@ bool PcapFileReader::readAt(uint64_t offset, uint32_t len, std::vector<unsigned 
     {
         return false;
     }
-    // 越界检查：offset 与 offset+len 都必须落在映射范围内
     if (offset > size_ || len > size_ - offset)
     {
         LOG_F(ERROR, "报文读取越界（偏移 %llu，长度 %u，文件大小 %llu）",

--- a/src/PdmlToJsonConverter.cpp
+++ b/src/PdmlToJsonConverter.cpp
@@ -111,7 +111,6 @@ bool PdmlToJsonConverter::convertXmlToJson(const std::string& xmlFile, const std
             return false;
         }
 
-        // 添加pdml属性，但跳过version、creator、time和capture_file
         for (rapidxml::xml_attribute<>* attr = pdmlNode->first_attribute(); attr;
              attr                            = attr->next_attribute())
         {
@@ -173,7 +172,6 @@ bool PdmlToJsonConverter::convertXmlToJson(const std::string& xmlFile, const std
                                                allocator);
                         }
 
-                        // 递归展开嵌套的 field 子节点
                         if (fieldNode->first_node("field"))
                         {
                             rapidjson::Value subFieldArray(rapidjson::kArrayType);
@@ -218,7 +216,6 @@ bool PdmlToJsonConverter::convertXmlToJson(const std::string& xmlFile, const std
 
         jsonDoc.AddMember("pdml", pdmlObj, allocator);
 
-        // 翻译showname字段，针对所有数据包的proto字段
         if (jsonDoc.HasMember("pdml") &&
             jsonDoc["pdml"].HasMember("packet") &&
             jsonDoc["pdml"]["packet"].IsArray() &&

--- a/src/ProcessResolver.cpp
+++ b/src/ProcessResolver.cpp
@@ -1,0 +1,212 @@
+#include "ProcessResolver.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+
+#include "processUtil.hpp"
+#include "tsharkDataType.hpp"
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <dirent.h>
+#include <unistd.h>
+#endif
+
+namespace
+{
+constexpr auto kRefreshInterval = std::chrono::seconds(2);
+
+inline uint32_t makeKey(bool isUdp, int port)
+{
+    return (isUdp ? (1u << 16) : 0u) | static_cast<uint32_t>(port);
+}
+} // namespace
+
+void ProcessResolver::annotate(Packet& packet)
+{
+    refreshIfStale();
+
+    bool isUdp = (packet.transport == "UDP");
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (table_.empty())
+        return;
+
+    auto it = table_.find(makeKey(isUdp, packet.src_port));
+    if (it == table_.end())
+        it = table_.find(makeKey(isUdp, packet.dst_port));
+    if (it == table_.end())
+        return;
+
+    packet.proc_name = it->second.first;
+    packet.proc_pid  = it->second.second;
+}
+
+void ProcessResolver::refreshIfStale()
+{
+    std::lock_guard<std::mutex> lk(mutex_);
+    auto now = std::chrono::steady_clock::now();
+    if (lastRefresh_.time_since_epoch().count() != 0 && now - lastRefresh_ < kRefreshInterval)
+        return;
+    lastRefresh_ = now;
+#if defined(__APPLE__)
+    refreshMacOS();
+#elif defined(__linux__)
+    refreshLinux();
+#endif
+}
+
+#if defined(__APPLE__)
+// lsof -F 字段模式：每行以一个字母开头标识字段，process 级字段（p/c）后跟若干 file 级字段（P/n）。
+// 用当前累计的 pid/command/protocol 状态机解析，命中一条 n（地址）就落一条 socket->进程 记录。
+void ProcessResolver::refreshMacOS()
+{
+    ProcessUtil::ProcHandle proc;
+    FILE* pipe = ProcessUtil::PopenEx({"lsof", "-i", "-n", "-P", "-F", "pcnP"}, &proc, "r");
+    if (!pipe)
+        return;
+
+    std::unordered_map<uint32_t, std::pair<std::string, int>> fresh;
+    int         curPid = 0;
+    std::string curCmd;
+    std::string curProto;
+    char        line[512];
+    while (fgets(line, sizeof(line), pipe) != nullptr)
+    {
+        size_t n = strlen(line);
+        while (n > 0 && (line[n - 1] == '\n' || line[n - 1] == '\r'))
+            line[--n] = '\0';
+        if (n == 0)
+            continue;
+        const char* val = line + 1;
+        switch (line[0])
+        {
+        case 'p':
+            curPid = atoi(val);
+            break;
+        case 'c':
+            curCmd = val;
+            break;
+        case 'P':
+            curProto = val;
+            break;
+        case 'n':
+        {
+            std::string addr  = val;
+            size_t      arrow = addr.find("->");
+            std::string local = (arrow == std::string::npos) ? addr : addr.substr(0, arrow);
+            size_t      colon = local.find_last_of(':');
+            if (colon == std::string::npos || curPid <= 0)
+                break;
+            int port = atoi(local.c_str() + colon + 1);
+            if (port <= 0)
+                break;
+            fresh[makeKey(curProto == "UDP", port)] = std::make_pair(curCmd, curPid);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    ProcessUtil::PcloseEx(pipe, proc);
+    table_.swap(fresh);
+}
+#else
+void ProcessResolver::refreshMacOS() {}
+#endif
+
+#if defined(__linux__)
+namespace
+{
+// 解析 /proc/net/{tcp,udp}[6] 一张表，把 inode 映射到 (isUdp, 本地端口)。
+// 格式：sl local_address rem_address st tx:rx tr:tm uid timeout inode ...
+//       local_address 形如 "0100007F:1F90"（十六进制 ip:port）。
+void parseProcNet(const char* path, bool isUdp,
+                   std::unordered_map<unsigned long, std::pair<bool, int>>& inodeToPort)
+{
+    std::ifstream in(path);
+    if (!in.is_open())
+        return;
+    std::string line;
+    std::getline(in, line); // 表头
+    while (std::getline(in, line))
+    {
+        std::istringstream iss(line);
+        std::string        sl, localAddr, remAddr, st, txrx, trtm, retr, uid, timeout, inode;
+        if (!(iss >> sl >> localAddr >> remAddr >> st >> txrx >> trtm >> retr >> uid >> timeout >>
+              inode))
+            continue;
+        size_t colon = localAddr.find(':');
+        if (colon == std::string::npos)
+            continue;
+        int         port  = static_cast<int>(strtol(localAddr.c_str() + colon + 1, nullptr, 16));
+        unsigned long ino = strtoul(inode.c_str(), nullptr, 10);
+        if (port > 0 && ino > 0)
+            inodeToPort[ino] = std::make_pair(isUdp, port);
+    }
+}
+} // namespace
+
+// 无 <filesystem>（C++11）：全程走 POSIX opendir/readdir/readlink，与 processUtil.cpp 一致的手写风格。
+void ProcessResolver::refreshLinux()
+{
+    std::unordered_map<unsigned long, std::pair<bool, int>> inodeToPort;
+    parseProcNet("/proc/net/tcp", false, inodeToPort);
+    parseProcNet("/proc/net/tcp6", false, inodeToPort);
+    parseProcNet("/proc/net/udp", true, inodeToPort);
+    parseProcNet("/proc/net/udp6", true, inodeToPort);
+    if (inodeToPort.empty())
+        return;
+
+    std::unordered_map<uint32_t, std::pair<std::string, int>> fresh;
+
+    DIR* procDir = opendir("/proc");
+    if (!procDir)
+        return;
+    struct dirent* pidEnt;
+    while ((pidEnt = readdir(procDir)) != nullptr)
+    {
+        const char* pidStr = pidEnt->d_name;
+        if (pidStr[0] < '0' || pidStr[0] > '9')
+            continue;
+        int pid = atoi(pidStr);
+
+        std::string fdDirPath = std::string("/proc/") + pidStr + "/fd";
+        DIR*        fdDir     = opendir(fdDirPath.c_str());
+        if (!fdDir)
+            continue; // 无权限访问其他用户进程的 fd 目录，跳过即可
+
+        std::string procName;
+        struct dirent* fdEnt;
+        while ((fdEnt = readdir(fdDir)) != nullptr)
+        {
+            if (fdEnt->d_name[0] == '.')
+                continue;
+            std::string fdPath = fdDirPath + "/" + fdEnt->d_name;
+            char        link[64];
+            ssize_t     len = readlink(fdPath.c_str(), link, sizeof(link) - 1);
+            if (len <= 0)
+                continue;
+            link[len] = '\0';
+            unsigned long inode = 0;
+            if (sscanf(link, "socket:[%lu]", &inode) != 1)
+                continue;
+            auto it = inodeToPort.find(inode);
+            if (it == inodeToPort.end())
+                continue;
+            if (procName.empty())
+            {
+                std::ifstream commFile(std::string("/proc/") + pidStr + "/comm");
+                std::getline(commFile, procName);
+            }
+            fresh[makeKey(it->second.first, it->second.second)] = std::make_pair(procName, pid);
+        }
+        closedir(fdDir);
+    }
+    closedir(procDir);
+    table_.swap(fresh);
+}
+#else
+void ProcessResolver::refreshLinux() {}
+#endif

--- a/src/gui/main_gui.cpp
+++ b/src/gui/main_gui.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -16,8 +17,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "imgui.h"
@@ -35,7 +36,6 @@ namespace
 
 using PacketPtr = std::shared_ptr<Packet>;
 
-// 文件是否已存在（保存前用来决定是否弹「覆盖确认」）。
 bool fileExists(const std::string& path)
 {
     if (path.empty())
@@ -44,15 +44,15 @@ bool fileExists(const std::string& path)
     return f.good();
 }
 
-// 文件名缺扩展名时补 .pcap。只看最后一段有无 '.'，避免把目录名里的点误判为扩展名。
-std::string withPcapSuffix(const std::string& path)
+// 文件名缺扩展名时补指定后缀。只看最后一段有无 '.'，避免把目录名里的点误判为扩展名。
+std::string withSuffix(const std::string& path, const char* ext)
 {
     if (path.empty())
         return path;
     size_t slash = path.find_last_of("/\\");
     size_t dot   = path.find_last_of('.');
     bool   hasExt = (dot != std::string::npos) && (slash == std::string::npos || dot > slash);
-    return hasExt ? path : path + ".pcap";
+    return hasExt ? path : path + ext;
 }
 
 // ---- 会话 / 统计聚合的数据结构 ----
@@ -60,12 +60,14 @@ std::string withPcapSuffix(const std::string& path)
 // 一条通信会话（按五元组归并的双向流）：端点、传输层、涉及的协议集合、包数/字节数。
 struct SessionInfo
 {
-    std::string           endpointA; // 规范化后较小的一端 "ip:port"
-    std::string           endpointB; // 较大的一端
-    std::string           transport; // TCP / UDP / 空
-    std::set<std::string> protocols; // 出现过的最高层协议（DNS/HTTP/TLS...）
-    uint64_t              packets = 0;
-    uint64_t              bytes   = 0;
+    std::string              endpointA; // 规范化后较小的一端 "ip:port"
+    std::string              endpointB; // 较大的一端
+    std::string              transport; // TCP / UDP / 空
+    // 出现过的最高层协议（DNS/HTTP/TLS...）：每会话通常 <10 种，线性查重比红黑树更快、无节点堆分配。
+    std::vector<std::string> protocols;
+    std::string              protocolsLabel; // protocols 逗号拼接，随聚合一次算好，供表格直接显示
+    uint64_t                 packets = 0;
+    uint64_t                 bytes   = 0;
 };
 
 // 计数条目（IP / 协议 / 归属地统计共用）：名字 + 包数 + 字节数。
@@ -84,9 +86,9 @@ struct AppState
     // 报文列表快照（从门面拷贝而来，UI 线程独占，绘制时不加锁）
     std::vector<PacketPtr> packets;
     PacketPtr              selectedPkt;        // 选中的报文（用指针而非下标，兼容分页/过滤）
-    std::vector<unsigned char> hex;            // 选中包的原始字节
-    uint32_t                   hexFrame = 0;   // hex 对应的帧号
-    DetailNode                 detail;         // 选中包的协议分层树
+    std::vector<unsigned char> hex;
+    uint32_t                   hexFrame = 0;
+    DetailNode                 detail;
     bool                       detailLoaded = false;
 
     // 过滤：view = 在 (全部 或 显示过滤结果) 基础上再按协议快速分类筛选后的可见集合
@@ -104,6 +106,7 @@ struct AppState
     // 离线载入 / 保存
     char pcapPathInput[512] = {0};
     char savePathInput[512] = {0};
+    char csvPathInput[512]  = {0};
     // 保存时目标文件已存在：暂存补全后的路径，弹「覆盖确认」再决定是否写入。
     std::string pendingSaveDest;
 
@@ -120,8 +123,10 @@ struct AppState
     bool                  liveCapturing = false;
     bool                  autoScroll    = true;
 
-    // 会话 / 统计的缓存：仅当报文数量变化时重建，避免每帧 O(N) 聚合。
-    size_t                   analyticsBuiltCount = (size_t)-1;
+    // 会话 / 统计的缓存：仅当报文数量变化时重建，避免每帧 O(N) 聚合。实时抓包时包数几乎每帧
+    // 都在涨，额外按 lastAnalyticsBuild 节流到约 300ms 一次，避免全量重新聚合跟渲染帧率走。
+    size_t                                analyticsBuiltCount = (size_t)-1;
+    std::chrono::steady_clock::time_point lastAnalyticsBuild;
     std::vector<SessionInfo> sessions;
     std::vector<CountItem>   ipStats;
     std::vector<CountItem>   protoStats;
@@ -170,7 +175,6 @@ bool containsIgnore(const std::string& hay, const char* needle)
     return hay.find(needle) != std::string::npos;
 }
 
-// 判断是否内网 / 环回地址（用于行内“内网”标签）。
 bool isPrivateIp(const std::string& ip)
 {
     if (ip.empty())
@@ -201,8 +205,17 @@ bool isPrivateIp(const std::string& ip)
 }
 
 // 协议名 → 颜色：为表格协议列提供彩色徽标，便于快速区分。
-ImVec4 protocolColor(const std::string& proto)
+// 计算本身是对短字符串做多次子串查找，代价不高，但每个可见行每帧都会重算一次；
+// 不同协议名种类很少（几十个封顶），用静态缓存换成一次哈希查找，且缓存生命周期
+// 与进程一致，不存在失效问题（协议名 → 颜色的映射关系本身就是纯函数、不会变化）。
+ImVec4 protocolColorUncached(const std::string& proto)
 {
+    if (containsIgnore(proto, "DoIP"))
+        return ImVec4(0.95f, 0.45f, 0.40f, 1.0f); // 红（Wireshark DoIP 色）
+    if (containsIgnore(proto, "UDS"))
+        return ImVec4(1.00f, 0.60f, 0.30f, 1.0f); // 橙
+    if (containsIgnore(proto, "CAN"))
+        return ImVec4(0.40f, 0.75f, 0.55f, 1.0f); // 绿
     if (containsIgnore(proto, "TCP"))
         return ImVec4(0.55f, 0.75f, 1.00f, 1.0f); // 蓝
     if (containsIgnore(proto, "UDP"))
@@ -220,6 +233,17 @@ ImVec4 protocolColor(const std::string& proto)
     if (containsIgnore(proto, "ARP"))
         return ImVec4(0.95f, 0.90f, 0.45f, 1.0f); // 黄
     return ImVec4(0.80f, 0.80f, 0.80f, 1.0f);
+}
+
+ImVec4 protocolColor(const std::string& proto)
+{
+    static std::unordered_map<std::string, ImVec4> cache;
+    auto                                            it = cache.find(proto);
+    if (it != cache.end())
+        return it->second;
+    ImVec4 c = protocolColorUncached(proto);
+    cache.emplace(proto, c);
+    return c;
 }
 
 // frame.time_epoch 格式化成本地时间 "MM-DD HH:MM:SS.mmm"。
@@ -452,12 +476,28 @@ void ensureAnalytics(AppState& s)
 {
     if (s.analyticsBuiltCount == s.packets.size())
         return;
+    if (s.liveCapturing)
+    {
+        auto now = std::chrono::steady_clock::now();
+        if (now - s.lastAnalyticsBuild < std::chrono::milliseconds(300))
+            return;
+        s.lastAnalyticsBuild = now;
+    }
     s.analyticsBuiltCount = s.packets.size();
 
     // 会话：按五元组（规范化端点对）归并
-    std::map<std::string, SessionInfo> sessMap;
+    std::unordered_map<std::string, SessionInfo> sessMap;
     // 统计：IP / 协议 / 归属地 计数
-    std::map<std::string, CountItem> ipMap, protoMap, locMap;
+    std::unordered_map<std::string, CountItem> ipMap, protoMap, locMap;
+
+    // 会话协议集合去重追加：每会话协议种类很少，线性查找比 std::set 更快、无红黑树节点分配。
+    auto addProtocol = [](SessionInfo& si, const std::string& proto)
+    {
+        for (const std::string& existing : si.protocols)
+            if (existing == proto)
+                return;
+        si.protocols.push_back(proto);
+    };
 
     for (const PacketPtr& pp : s.packets)
     {
@@ -477,7 +517,29 @@ void ensureAnalytics(AppState& s)
                 si.transport = p.transport;
             }
             if (!p.protocol.empty())
-                si.protocols.insert(p.protocol);
+                addProtocol(si, p.protocol);
+            si.packets++;
+            si.bytes += p.len;
+        }
+        // CAN 链路报文无 IP 层，按唯一 CAN ID 归并成一条"会话"（总线广播，无点对点概念）。
+        // 判定：CAN 链路从不经过 parseTcp/parseUdp，故 transport 恒为空；protocol 只会是
+        // "UDS"（直接 UDS-over-CAN / ISO-TP 重组完成）或以 "CAN" 开头（普通 CAN/CAN FD 帧）。
+        else if (p.transport.empty() &&
+                 (p.protocol.compare(0, 3, "CAN") == 0 || p.protocol == "UDS"))
+        {
+            char keyBuf[32];
+            std::snprintf(keyBuf, sizeof(keyBuf), "CAN|%u", p.can_id);
+            SessionInfo& si = sessMap[keyBuf];
+            if (si.packets == 0)
+            {
+                char idBuf[24];
+                std::snprintf(idBuf, sizeof(idBuf), "CAN ID 0x%x", p.can_id);
+                si.endpointA = idBuf;
+                si.endpointB = "(总线广播)";
+                si.transport = "CAN";
+            }
+            if (!p.protocol.empty())
+                addProtocol(si, p.protocol);
             si.packets++;
             si.bytes += p.len;
         }
@@ -514,7 +576,7 @@ void ensureAnalytics(AppState& s)
         }
     }
 
-    auto toSortedVec = [](std::map<std::string, CountItem>& m)
+    auto toSortedVec = [](std::unordered_map<std::string, CountItem>& m)
     {
         std::vector<CountItem> v;
         v.reserve(m.size());
@@ -528,7 +590,12 @@ void ensureAnalytics(AppState& s)
     s.sessions.clear();
     s.sessions.reserve(sessMap.size());
     for (auto& kv : sessMap)
-        s.sessions.push_back(kv.second);
+    {
+        SessionInfo& si = kv.second;
+        for (const std::string& pr : si.protocols)
+            si.protocolsLabel += (si.protocolsLabel.empty() ? "" : ",") + pr;
+        s.sessions.push_back(std::move(si));
+    }
     std::sort(s.sessions.begin(), s.sessions.end(),
               [](const SessionInfo& x, const SessionInfo& y) { return x.packets > y.packets; });
 
@@ -560,6 +627,12 @@ bool sessionMatches(const SessionInfo& si, int cat)
         return hasProto("TLS") || hasProto("SSL");
     case 6:
         return hasProto("SSH");
+    case 7:
+        return hasProto("DoIP");
+    case 8:
+        return hasProto("UDS");
+    case 9:
+        return si.transport == "CAN";
     default:
         return true;
     }
@@ -596,7 +669,7 @@ void drawToolbar(AppState& s)
     ImGui::BeginDisabled(s.busy || s.session.pcapPath().empty());
     if (ImGui::Button("保存"))
     {
-        std::string dest = withPcapSuffix(s.savePathInput); // 缺后缀补 .pcap
+        std::string dest = withSuffix(s.savePathInput, ".pcap");
         if (dest.empty())
         {
             s.status = "请先填写保存路径";
@@ -611,6 +684,24 @@ void drawToolbar(AppState& s)
         {
             s.status = s.session.savePcapAs(dest) ? ("已保存: " + dest) : "保存失败";
         }
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    ImGui::TextUnformatted("  |  导出CSV:");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(240);
+    ImGui::InputTextWithHint("##csvpath", "导出为 .csv 路径（缺目录会自动创建）", s.csvPathInput,
+                             sizeof(s.csvPathInput));
+    ImGui::SameLine();
+    ImGui::BeginDisabled(s.busy || s.session.pcapPath().empty());
+    if (ImGui::Button("导出CSV"))
+    {
+        std::string dest = withSuffix(s.csvPathInput, ".csv");
+        if (dest.empty())
+            s.status = "请先填写导出路径";
+        else
+            s.status = s.session.exportPacketsCsv(dest) ? ("已导出: " + dest) : "导出失败";
     }
     ImGui::EndDisabled();
 
@@ -810,12 +901,13 @@ void drawPacketRow(AppState& s, const PacketPtr& p)
     }
 
     ImGui::TableSetColumnIndex(1);
-    ImGui::TextUnformatted(formatEpoch(p->time).c_str());
+    if (p->display_time_cache.empty() && p->time > 0.0)
+        p->display_time_cache = formatEpoch(p->time);
+    ImGui::TextUnformatted(p->display_time_cache.c_str());
 
     ImGui::TableSetColumnIndex(2);
     ImGui::Text("%.6f", p->time);
 
-    // 源 IP/Mac（+ 内网标签）
     ImGui::TableSetColumnIndex(3);
     ImGui::TextUnformatted(p->src_ip.empty() ? p->src_mac.c_str() : p->src_ip.c_str());
     if (isPrivateIp(p->src_ip))
@@ -829,7 +921,6 @@ void drawPacketRow(AppState& s, const PacketPtr& p)
     if (p->src_port)
         ImGui::Text("%u", p->src_port);
 
-    // 目的 IP/Mac（+ 内网标签）
     ImGui::TableSetColumnIndex(6);
     ImGui::TextUnformatted(p->dst_ip.empty() ? p->dst_mac.c_str() : p->dst_ip.c_str());
     if (isPrivateIp(p->dst_ip))
@@ -843,7 +934,6 @@ void drawPacketRow(AppState& s, const PacketPtr& p)
     if (p->dst_port)
         ImGui::Text("%u", p->dst_port);
 
-    // 协议（彩色徽标）
     ImGui::TableSetColumnIndex(9);
     ImGui::TextColored(protocolColor(p->protocol), "%s", p->protocol.c_str());
 
@@ -851,6 +941,11 @@ void drawPacketRow(AppState& s, const PacketPtr& p)
     ImGui::Text("%u", p->len);
     ImGui::TableSetColumnIndex(11);
     ImGui::TextUnformatted(p->info.c_str());
+
+    // 进程归属（仅实时抓包时可能有值；离线回放/未命中恒为空）
+    ImGui::TableSetColumnIndex(12);
+    if (p->proc_pid)
+        ImGui::Text("%s (%d)", p->proc_name.c_str(), p->proc_pid);
 }
 
 void drawPacketTable(AppState& s)
@@ -876,9 +971,8 @@ void drawPacketTable(AppState& s)
     const ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                   ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollX |
                                   ImGuiTableFlags_Resizable;
-    // 表格占据除底部分页条外的空间
     float tableHeight = ImGui::GetContentRegionAvail().y - (s.liveCapturing ? 0.0f : 34.0f);
-    if (ImGui::BeginTable("packets", 12, flags, ImVec2(0, tableHeight)))
+    if (ImGui::BeginTable("packets", 13, flags, ImVec2(0, tableHeight)))
     {
         // 冻结表头行 + 首列（No.）：横向滚动时帧号始终可见，便于对照
         ImGui::TableSetupScrollFreeze(1, 1);
@@ -894,6 +988,7 @@ void drawPacketTable(AppState& s)
         ImGui::TableSetupColumn("协议", ImGuiTableColumnFlags_WidthFixed, 70);
         ImGui::TableSetupColumn("大小", ImGuiTableColumnFlags_WidthFixed, 55);
         ImGui::TableSetupColumn("信息", ImGuiTableColumnFlags_WidthFixed, 600);
+        ImGui::TableSetupColumn("进程", ImGuiTableColumnFlags_WidthFixed, 140);
         ImGui::TableHeadersRow();
 
         if (s.liveCapturing)
@@ -909,7 +1004,6 @@ void drawPacketTable(AppState& s)
         }
         else
         {
-            // 离线：分页渲染当前页切片
             int begin = s.page * s.pageSize;
             int end   = std::min((int)s.view.size(), begin + s.pageSize);
             for (int row = begin; row < end; row++)
@@ -951,22 +1045,21 @@ void drawPacketTable(AppState& s)
 }
 
 // 递归渲染协议分层树的一个节点
-void renderDetailNode(const DetailNode& n, int idx)
+void renderDetailNode(DetailNode& n, int idx)
 {
     ImGui::PushID(idx);
     if (n.children.empty())
     {
-        std::string text = n.label;
-        if (!n.value.empty())
-            text += ": " + n.value;
-        ImGui::TreeNodeEx(text.c_str(), ImGuiTreeNodeFlags_Leaf |
+        if (n.display_text_cache.empty())
+            n.display_text_cache = n.value.empty() ? n.label : n.label + ": " + n.value;
+        ImGui::TreeNodeEx(n.display_text_cache.c_str(), ImGuiTreeNodeFlags_Leaf |
                                             ImGuiTreeNodeFlags_NoTreePushOnOpen |
                                             ImGuiTreeNodeFlags_Bullet);
     }
     else if (ImGui::TreeNode(n.label.c_str()))
     {
         int i = 0;
-        for (const DetailNode& c : n.children)
+        for (DetailNode& c : n.children)
             renderDetailNode(c, i++);
         ImGui::TreePop();
     }
@@ -994,7 +1087,7 @@ void drawDetail(AppState& s)
     if (s.detailLoaded && !s.detail.children.empty())
     {
         int i = 0;
-        for (const DetailNode& proto : s.detail.children)
+        for (DetailNode& proto : s.detail.children)
             renderDetailNode(proto, i++);
     }
     else if (s.detailPending.valid())
@@ -1040,15 +1133,19 @@ void drawSessions(AppState& s)
     ImGui::SameLine();
     ImGui::SetNextItemWidth(160);
     const char* cats[] = {"全部会话", "TCP会话", "UDP会话", "DNS会话",
-                          "HTTP会话", "SSL/TLS会话", "SSH会话"};
+                          "HTTP会话", "SSL/TLS会话", "SSH会话",
+                          "DoIP会话", "UDS会话", "CAN会话"};
     ImGui::Combo("##sesscat", &s.sessionCategory, cats, IM_ARRAYSIZE(cats));
 
-    size_t shown = 0;
-    for (const SessionInfo& si : s.sessions)
-        if (sessionMatches(si, s.sessionCategory))
-            shown++;
+    // 先按分类过滤物化出可见下标数组，再对该数组做 clipper 虚拟化（不能直接对 s.sessions
+    // 做 clipper，因为分类过滤后可见行数与总行数不一致）。
+    std::vector<size_t> visible;
+    visible.reserve(s.sessions.size());
+    for (size_t i = 0; i < s.sessions.size(); ++i)
+        if (sessionMatches(s.sessions[i], s.sessionCategory))
+            visible.push_back(i);
     ImGui::SameLine();
-    ImGui::Text("  共 %zu 个会话", shown);
+    ImGui::Text("  共 %zu 个会话", visible.size());
 
     const ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                   ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable;
@@ -1063,27 +1160,26 @@ void drawSessions(AppState& s)
         ImGui::TableSetupColumn("字节", ImGuiTableColumnFlags_WidthFixed, 90);
         ImGui::TableHeadersRow();
 
-        for (const SessionInfo& si : s.sessions)
-        {
-            if (!sessionMatches(si, s.sessionCategory))
-                continue;
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted(si.endpointA.c_str());
-            ImGui::TableSetColumnIndex(1);
-            ImGui::TextUnformatted(si.endpointB.c_str());
-            ImGui::TableSetColumnIndex(2);
-            ImGui::TextUnformatted(si.transport.c_str());
-            ImGui::TableSetColumnIndex(3);
-            std::string protos;
-            for (const std::string& pr : si.protocols)
-                protos += (protos.empty() ? "" : ",") + pr;
-            ImGui::TextUnformatted(protos.c_str());
-            ImGui::TableSetColumnIndex(4);
-            ImGui::Text("%llu", (unsigned long long)si.packets);
-            ImGui::TableSetColumnIndex(5);
-            ImGui::Text("%llu", (unsigned long long)si.bytes);
-        }
+        ImGuiListClipper clipper;
+        clipper.Begin((int)visible.size());
+        while (clipper.Step())
+            for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++)
+            {
+                const SessionInfo& si = s.sessions[visible[row]];
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::TextUnformatted(si.endpointA.c_str());
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextUnformatted(si.endpointB.c_str());
+                ImGui::TableSetColumnIndex(2);
+                ImGui::TextUnformatted(si.transport.c_str());
+                ImGui::TableSetColumnIndex(3);
+                ImGui::TextUnformatted(si.protocolsLabel.c_str());
+                ImGui::TableSetColumnIndex(4);
+                ImGui::Text("%llu", (unsigned long long)si.packets);
+                ImGui::TableSetColumnIndex(5);
+                ImGui::Text("%llu", (unsigned long long)si.bytes);
+            }
         ImGui::EndTable();
     }
 }
@@ -1100,16 +1196,20 @@ void drawCountTable(const char* id, const char* nameCol, const std::vector<Count
         ImGui::TableSetupColumn("包数", ImGuiTableColumnFlags_WidthFixed, 80);
         ImGui::TableSetupColumn("字节", ImGuiTableColumnFlags_WidthFixed, 100);
         ImGui::TableHeadersRow();
-        for (const CountItem& c : items)
-        {
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted(c.name.c_str());
-            ImGui::TableSetColumnIndex(1);
-            ImGui::Text("%llu", (unsigned long long)c.packets);
-            ImGui::TableSetColumnIndex(2);
-            ImGui::Text("%llu", (unsigned long long)c.bytes);
-        }
+        ImGuiListClipper clipper;
+        clipper.Begin((int)items.size());
+        while (clipper.Step())
+            for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++)
+            {
+                const CountItem& c = items[row];
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::TextUnformatted(c.name.c_str());
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("%llu", (unsigned long long)c.packets);
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%llu", (unsigned long long)c.bytes);
+            }
         ImGui::EndTable();
     }
 }
@@ -1336,11 +1436,6 @@ int main(int, char**)
             if (ImGui::BeginTabItem("查询"))
             {
                 drawQuery(state);
-                ImGui::EndTabItem();
-            }
-            if (ImGui::BeginTabItem("进程分析"))
-            {
-                ImGui::TextDisabled("进程分析（socket→进程 映射）依赖平台特定能力，暂未实现。");
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
     loguru::init(argc, argv);
     loguru::add_file(capture_log_name.c_str(), loguru::Append, loguru::Verbosity_MAX);
 
-    // 自动定位 tshark：环境变量 EASYTSHARK_TSHARK → 默认路径 → PATH →（Win）注册表 → 常见目录。
+    // 解析顺序见 TsharkCommand::resolveTsharkPath 的实现注释。
     std::string     tsharkPath = TsharkCommand::resolveTsharkPath();
     AnalysisSession session(tsharkPath, "data");
 

--- a/src/processUtil.cpp
+++ b/src/processUtil.cpp
@@ -145,7 +145,7 @@ FILE* spawnWithPipe(const std::string& cmdline, ProcessUtil::ProcHandle* pidOut,
     FILE* fp = _fdopen(fd, readMode ? "r" : "w");
     if (!fp)
     {
-        _close(fd); // 连带关闭底层句柄
+        _close(fd);
         return nullptr;
     }
     return fp;
@@ -241,7 +241,7 @@ int ProcessUtil::PcloseEx(FILE* pipe, ProcHandle pid)
     if (!pipe)
         return -1;
 
-    fclose(pipe); // 连带关闭底层管道句柄
+    fclose(pipe);
 
     DWORD exitCode = 0;
     if (ValidProc(pid))
@@ -405,7 +405,7 @@ FILE* ProcessUtil::PopenEx(const std::vector<std::string>& argv, ProcHandle* pid
             dup2(pipefd[0], STDIN_FILENO);
         }
 
-        // 用 execvp 直接执行程序，不经过 /bin/sh，参数不会被 shell 解释
+        // 同 Exec：execvp 不经 shell，规避元字符注入
         execvp(cargv[0], cargv.data());
         _exit(127);
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -256,7 +256,7 @@ std::string CommonUtil::get_timestamp()
 void CommonUtil::pruneLogFiles(const std::string& dir, size_t keep)
 {
 #if defined(_WIN32)
-    // Windows 下用 _findfirst/_findnext 枚举 *.log；按文件名时间戳排序后删除最旧的。
+    // Windows 下用 _findfirst/_findnext 枚举 *.log；按修改时间排序后删除最旧的（见下方 sort）。
     std::vector<std::string> files;
     std::string              pattern = dir + "\\*.log";
     struct _finddata_t       fd;
@@ -722,6 +722,56 @@ std::string SQLiteUtil::buildFuzzyQuery(const std::map<std::string, std::string>
     return sql;
 }
 
+namespace
+{
+// StringRef 引用 Packet 已有内存，避免再拷贝；packet 须在序列化完成前存活，不悬垂。
+rapidjson::Value packetToJsonValue(const Packet& packet, rapidjson::Document::AllocatorType& allocator)
+{
+    rapidjson::Value packetObj(rapidjson::kObjectType);
+    packetObj.AddMember("frame_number", rapidjson::Value(packet.frame_number), allocator);
+    packetObj.AddMember("time", rapidjson::Value(packet.time), allocator);
+    packetObj.AddMember("cap_len", rapidjson::Value(packet.cap_len), allocator);
+    packetObj.AddMember("len", rapidjson::Value(packet.len), allocator);
+    packetObj.AddMember("src_mac", rapidjson::StringRef(packet.src_mac.c_str()), allocator);
+    packetObj.AddMember("dst_mac", rapidjson::StringRef(packet.dst_mac.c_str()), allocator);
+    packetObj.AddMember("src_ip", rapidjson::StringRef(packet.src_ip.c_str()), allocator);
+    packetObj.AddMember("src_location", rapidjson::StringRef(packet.src_location.c_str()),
+                        allocator);
+    packetObj.AddMember("src_port", rapidjson::Value(packet.src_port), allocator);
+    packetObj.AddMember("dst_ip", rapidjson::StringRef(packet.dst_ip.c_str()), allocator);
+    packetObj.AddMember("dst_location", rapidjson::StringRef(packet.dst_location.c_str()),
+                        allocator);
+    packetObj.AddMember("dst_port", rapidjson::Value(packet.dst_port), allocator);
+    packetObj.AddMember("protocol", rapidjson::StringRef(packet.protocol.c_str()), allocator);
+    packetObj.AddMember("info", rapidjson::StringRef(packet.info.c_str()), allocator);
+    packetObj.AddMember("file_offset", rapidjson::Value(static_cast<uint64_t>(packet.file_offset)),
+                        allocator);
+    packetObj.AddMember("transport", rapidjson::StringRef(packet.transport.c_str()), allocator);
+    packetObj.AddMember("can_id", rapidjson::Value(packet.can_id), allocator);
+    packetObj.AddMember("proc_name", rapidjson::StringRef(packet.proc_name.c_str()), allocator);
+    packetObj.AddMember("proc_pid", rapidjson::Value(packet.proc_pid), allocator);
+    return packetObj;
+}
+} // namespace
+
+rapidjson::Value
+CommonUtil::packetsToJsonValue(std::vector<std::shared_ptr<Packet>>::const_iterator begin,
+                               std::vector<std::shared_ptr<Packet>>::const_iterator end,
+                               rapidjson::Document::AllocatorType&                  allocator)
+{
+    rapidjson::Value arr(rapidjson::kArrayType);
+    arr.Reserve(static_cast<rapidjson::SizeType>(std::distance(begin, end)), allocator);
+    for (auto it = begin; it != end; ++it)
+        arr.PushBack(packetToJsonValue(**it, allocator), allocator);
+    return arr;
+}
+
+rapidjson::Value CommonUtil::packetsToJsonValue(const std::vector<std::shared_ptr<Packet>>& packets,
+                                                rapidjson::Document::AllocatorType& allocator)
+{
+    return packetsToJsonValue(packets.begin(), packets.end(), allocator);
+}
+
 std::string CommonUtil::packetsToJson(const std::vector<std::shared_ptr<Packet>>& packets)
 {
     rapidjson::Document document;
@@ -729,38 +779,7 @@ std::string CommonUtil::packetsToJson(const std::vector<std::shared_ptr<Packet>>
     rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
 
     document.AddMember("total", rapidjson::Value((int)packets.size()), allocator);
-
-    rapidjson::Value packetsArray(rapidjson::kArrayType);
-    packetsArray.Reserve(static_cast<rapidjson::SizeType>(packets.size()), allocator);
-
-    for (const auto& packet : packets)
-    {
-        rapidjson::Value packetObj(rapidjson::kObjectType);
-
-        // StringRef 引用 Packet 已有内存，避免再拷贝；packet 在序列化完成前存活，不悬垂。
-        packetObj.AddMember("frame_number", rapidjson::Value(packet->frame_number), allocator);
-        packetObj.AddMember("time", rapidjson::Value(packet->time), allocator);
-        packetObj.AddMember("cap_len", rapidjson::Value(packet->cap_len), allocator);
-        packetObj.AddMember("len", rapidjson::Value(packet->len), allocator);
-        packetObj.AddMember("src_mac", rapidjson::StringRef(packet->src_mac.c_str()), allocator);
-        packetObj.AddMember("dst_mac", rapidjson::StringRef(packet->dst_mac.c_str()), allocator);
-        packetObj.AddMember("src_ip", rapidjson::StringRef(packet->src_ip.c_str()), allocator);
-        packetObj.AddMember("src_location", rapidjson::StringRef(packet->src_location.c_str()),
-                            allocator);
-        packetObj.AddMember("src_port", rapidjson::Value(packet->src_port), allocator);
-        packetObj.AddMember("dst_ip", rapidjson::StringRef(packet->dst_ip.c_str()), allocator);
-        packetObj.AddMember("dst_location", rapidjson::StringRef(packet->dst_location.c_str()),
-                            allocator);
-        packetObj.AddMember("dst_port", rapidjson::Value(packet->dst_port), allocator);
-        packetObj.AddMember("protocol", rapidjson::StringRef(packet->protocol.c_str()), allocator);
-        packetObj.AddMember("info", rapidjson::StringRef(packet->info.c_str()), allocator);
-        packetObj.AddMember("file_offset",
-                            rapidjson::Value(static_cast<uint64_t>(packet->file_offset)), allocator);
-
-        packetsArray.PushBack(packetObj, allocator);
-    }
-
-    document.AddMember("packets", packetsArray, allocator);
+    document.AddMember("packets", packetsToJsonValue(packets, allocator), allocator);
 
     rapidjson::StringBuffer                    buffer;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -1,10 +1,5 @@
-// EasyTshark Web 前端路由层：把 HTTP 路由、令牌鉴权、Origin 校验、/api/load 路径白名单集中于此，
-// 生产入口与单元测试复用。所有逻辑经 AnalysisSession 门面，本文件只做 HTTP 请求 ↔ 门面调用的装配。
-//
-// 线程：httplib 每连接一线程，处理器可能并发进入；用 opMutex_ 串行化所有写操作（粗粒度锁，
-// 单用户工具足够）；实时抓包回调在抓包线程执行，只推进带独立锁的 liveBuffer_，与 opMutex_ 互不阻塞。
-// 安全：所有 /api/* 须带 X-Auth-Token；浏览器请求还校验 Origin==Host（防 DNS rebinding）；
-// /api/load 仅允许用户主目录或 data/ 下的文件。静态资源不要求 token。
+// EasyTshark Web 前端路由层：HTTP 路由、鉴权、Origin 校验、/api/load 路径白名单集中于此，
+// 生产入口与单元测试复用；所有逻辑经 AnalysisSession 门面装配（线程/安全细节见各校验函数注释）。
 
 #include <climits>
 #include <cstdlib>
@@ -197,11 +192,13 @@ std::string jsonStr(const rapidjson::Document& doc, const char* key)
 }
 
 // 把协议分层树递归序列化成 rapidjson 值：{label,value,children:[...]}。
+// StringRef 引用 node 已有内存：node 由调用方在同一 handler 作用域内构建，
+// 存活到 doc.Accept(writer) 完成，无需再深拷贝一份。
 rapidjson::Value detailToJson(const DetailNode& node, rapidjson::Document::AllocatorType& alloc)
 {
     rapidjson::Value obj(rapidjson::kObjectType);
-    obj.AddMember("label", rapidjson::Value(node.label.c_str(), alloc), alloc);
-    obj.AddMember("value", rapidjson::Value(node.value.c_str(), alloc), alloc);
+    obj.AddMember("label", rapidjson::StringRef(node.label.c_str(), node.label.size()), alloc);
+    obj.AddMember("value", rapidjson::StringRef(node.value.c_str(), node.value.size()), alloc);
 
     rapidjson::Value children(rapidjson::kArrayType);
     for (const DetailNode& child : node.children)
@@ -245,7 +242,6 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
         return httplib::Server::HandlerResponse::Unhandled;
     });
 
-    // 服务运行状态：前端轮询用（实时抓包时据此拉取增量、更新计数）。
     svr.Get("/api/status", [st](const httplib::Request&, httplib::Response& res)
     {
         std::lock_guard<std::mutex> lk(st->opMutex);
@@ -311,19 +307,19 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
                 page  = 0;
             }
             size_t end = std::min(total, begin + static_cast<size_t>(pageSize));
-            std::vector<PacketPtr> slice(snap->begin() + begin, snap->begin() + end);
 
-            // 用 rapidjson 组装 {total,page,pageSize,packets:[...]}，packets 复用 packetsToJson 结果。
+            // 直接用迭代器区间写入 doc 自己的 allocator：不拷出中间 vector（每个元素是一次
+            // shared_ptr 原子 incref/decref），也不走"序列化成字符串再 Parse 再 CopyFrom"的
+            // 三次往返，只在最外层序列化一次。
             rapidjson::Document doc;
             doc.SetObject();
             doc.AddMember("total", static_cast<uint64_t>(total), doc.GetAllocator());
             doc.AddMember("page", static_cast<int>(page), doc.GetAllocator());
             doc.AddMember("pageSize", static_cast<int>(pageSize), doc.GetAllocator());
-            rapidjson::Document innerDoc;
-            innerDoc.Parse(CommonUtil::packetsToJson(slice).c_str());
-            rapidjson::Value packetsVal;
-            packetsVal.CopyFrom(innerDoc["packets"], doc.GetAllocator());
-            doc.AddMember("packets", packetsVal, doc.GetAllocator());
+            doc.AddMember("packets",
+                         CommonUtil::packetsToJsonValue(snap->begin() + begin, snap->begin() + end,
+                                                        doc.GetAllocator()),
+                         doc.GetAllocator());
             rapidjson::StringBuffer                    buf;
             rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
             doc.Accept(writer);
@@ -336,7 +332,6 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
         sendJson(res, CommonUtil::packetsToJson(*snap));
     });
 
-    // 指定帧号的原始字节（十六进制视图）。
     svr.Get(R"(/api/hex/(\d+))", [st](const httplib::Request& req, httplib::Response& res)
     {
         // 用 strtoul 而非会抛 out_of_range 的 stoul：超长数字串越界返回 ULONG_MAX，自然走 404。
@@ -353,7 +348,6 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
                           "\"}");
     });
 
-    // 指定帧号的协议分层树（详情面板）。
     svr.Get(R"(/api/detail/(\d+))", [st](const httplib::Request& req, httplib::Response& res)
     {
         uint32_t                    frame =
@@ -375,7 +369,7 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
         sendJson(res, buf.GetString());
     });
 
-    // 载入并解析服务器本地的一个 pcap 文件（注意：路径在服务器端文件系统解析）。
+    // 注意：path 是服务器端文件系统路径（非浏览器本地文件），白名单见 isPathAllowed。
     svr.Post("/api/load", [st](const httplib::Request& req, httplib::Response& res)
     {
         rapidjson::Document doc;
@@ -391,7 +385,6 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
             return;
         }
         std::lock_guard<std::mutex> lk(st->opMutex);
-        // 路径白名单：只允许载入用户主目录 / data/ 下的文件，避免任意文件被读取。
         if (!isPathAllowed(path))
         {
             sendError(res, "路径不在允许范围内（仅限用户主目录或 data/ 下的文件）", 403);
@@ -625,7 +618,6 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
     });
 
     // 导出当前报文快照为 CSV（服务器端路径），供 Excel / 数据分析工具二次加工。
-    // 路径同样受白名单约束（只写用户主目录或 data/ 下）。
     svr.Post("/api/export/csv", [st](const httplib::Request& req, httplib::Response& res)
     {
         rapidjson::Document doc;
@@ -657,6 +649,43 @@ void registerRoutes(httplib::Server& svr, std::shared_ptr<WebState> st)
         catch (const std::exception& e)
         {
             sendError(res, std::string("导出 CSV 失败：") + e.what());
+            return;
+        }
+        sendJson(res, "{\"ok\":true,\"path\":\"" + path + "\"}");
+    });
+
+    // 把当前载入/抓包的 pcap 另存到服务器端路径（对齐桌面端"保存"按钮）。
+    svr.Post("/api/export/pcap", [st](const httplib::Request& req, httplib::Response& res)
+    {
+        rapidjson::Document doc;
+        if (!parseBody(req, doc))
+        {
+            sendError(res, "请求体不是合法 JSON", 400);
+            return;
+        }
+        std::string path = jsonStr(doc, "path");
+        if (path.empty())
+        {
+            sendError(res, "缺少 path 字段", 400);
+            return;
+        }
+        if (!isPathAllowed(path))
+        {
+            sendError(res, "路径不在允许范围内（仅限用户主目录或 data/ 下的文件）", 403);
+            return;
+        }
+        std::lock_guard<std::mutex> lk(st->opMutex);
+        try
+        {
+            if (!st->session.savePcapAs(path))
+            {
+                sendError(res, "保存 pcap 失败（是否已载入或抓包？）");
+                return;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            sendError(res, std::string("保存 pcap 失败：") + e.what());
             return;
         }
         sendJson(res, "{\"ok\":true,\"path\":\"" + path + "\"}");

--- a/src/web/main_web.cpp
+++ b/src/web/main_web.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
     svr.set_payload_max_length(16u * 1024 * 1024);
     registerWebRoutes(svr, session, token);
 
-    // 托管静态前端；根路径重定向到 index.html。
+    // 托管静态前端：httplib 挂载该目录后，访问 / 会在目录内回退到 index.html（非 HTTP 重定向）。
     std::string webRoot = resolveWebRoot();
     if (!svr.set_mount_point("/", webRoot))
         LOG_F(WARNING, "静态目录挂载失败：%s（API 仍可用，页面不可用）", webRoot.c_str());

--- a/tests/gen_can_pcap.py
+++ b/tests/gen_can_pcap.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# 生成一份纯字节拼装的 CAN 测试 pcap（DLT 227 / SocketCAN），不依赖 scapy、
+# 不需要真实 CAN 总线或硬件。字节布局与 tests/test_native_engine.cpp 里
+# NativeParserTest 用到的 canSocketcanFrame/canFdSocketcanFrame 等 helper 完全一致，
+# 用于手工验证"CAN会话"分组与 UDS-over-CAN / ISO-TP 重组这几个解析特性。
+#
+# 注意：这份 pcap 只有在被自研引擎（NativeAnalyzer）解析时才会识别出 can_id 和
+# CAN/UDS 协议名——tshark 转发路径（PacketParser.cpp）完全没有 CAN 相关逻辑。
+# 若本机装了 tshark，AnalysisSession 默认会优先用 tshark 后端，此时载入这份 pcap
+# 不会出现"CAN会话"。要强制走自研引擎，在 GUI/Web 的"tshark 路径"里填一个不存在
+# 的路径（如 /nonexistent）再载入即可。
+
+import struct
+import sys
+
+PCAP_MAGIC = 0xa1b2c3d4
+LINKTYPE_SOCKETCAN = 227
+
+
+def le32(x):
+    return struct.pack('<I', x)
+
+
+def le16(x):
+    return struct.pack('<H', x)
+
+
+def global_header(link_type):
+    return (le32(PCAP_MAGIC) + le16(2) + le16(4) +
+            le32(0) + le32(0) + le32(65535) + le32(link_type))
+
+
+def record(ts_sec, frame):
+    return le32(ts_sec) + le32(0) + le32(len(frame)) + le32(len(frame)) + frame
+
+
+def can_classic_frame(can_id, data):
+    dlc = len(data)
+    return le32(can_id) + bytes([dlc, 0, 0, 0]) + bytes(data)
+
+
+def can_fd_frame(can_id, flags, data):
+    length = len(data)
+    return le32(can_id) + bytes([flags, length, 0, 0]) + bytes(data)
+
+
+def isotp_first_frame(payload):
+    head = bytes([0x10, len(payload)])
+    return head + bytes(payload[:6])
+
+
+def isotp_consecutive_frame(payload, seq):
+    head = bytes([0x20 | (seq & 0x0F)])
+    body = bytes(payload[6:])
+    frame = head + body
+    return frame + bytes([0xAA] * (8 - len(frame)))
+
+
+def build_frames():
+    frames = []
+
+    # 两条普通 CAN 会话（不同 CAN ID，无 UDS 特征）
+    frames.append(can_classic_frame(0x100, [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77]))
+    frames.append(can_classic_frame(0x200, [0xDE, 0xAD, 0xBE, 0xEF]))
+
+    # ISO-TP 单帧 UDS：CAN 0x123，PCI=0x02（长度2），SID=0x3E（TesterPresent）
+    frames.append(can_classic_frame(0x123, [0x02, 0x3E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+
+    # ISO-TP 多帧 UDS：CAN 0x7E8，First Frame + Consecutive Frame，
+    # 负载是 ReadDataByIdentifier 正响应 62 F1 90 + "ABCDEFG"
+    payload = [0x62, 0xF1, 0x90, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]
+    frames.append(can_classic_frame(0x7E8, isotp_first_frame(payload)))
+    frames.append(can_classic_frame(0x7E8, isotp_consecutive_frame(payload, 1)))
+
+    # CAN FD：flags=0x80 仅 FDF → "CAN FD"
+    frames.append(can_fd_frame(0x1FED, 0x80, list(range(16))))
+
+    # CAN FD：flags=0x83 = FDF+BRS+ESI → "CAN FD BRS ESI"
+    frames.append(can_fd_frame(0x1FEE, 0x83, list(range(32))))
+
+    return frames
+
+
+def main():
+    out_path = sys.argv[1] if len(sys.argv) > 1 else 'data/pcaps/can_demo.pcap'
+    frames = build_frames()
+    with open(out_path, 'wb') as f:
+        f.write(global_header(LINKTYPE_SOCKETCAN))
+        for i, frame in enumerate(frames, start=1):
+            f.write(record(i, frame))
+    print('生成 %s：%d 个 CAN 帧（DLT 227）' % (out_path, len(frames)))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_native_engine.cpp
+++ b/tests/test_native_engine.cpp
@@ -236,6 +236,87 @@ std::vector<unsigned char> makePcapFile(const std::vector<unsigned char>& f1,
     pushBytes(v, f2);
     return v;
 }
+
+// 指定链路类型的单包 pcap（小端），供 CAN 等非以太网链路测试
+std::vector<unsigned char> makePcapFileLinkType(uint32_t linkType,
+                                                const std::vector<unsigned char>& f1)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, 0xa1b2c3d4);
+    pushLe16(v, 2);
+    pushLe16(v, 4);
+    pushLe32(v, 0);
+    pushLe32(v, 0);
+    pushLe32(v, 65535);
+    pushLe32(v, linkType);
+    pushLe32(v, 1); // ts_sec
+    pushLe32(v, 0);
+    pushLe32(v, static_cast<uint32_t>(f1.size()));
+    pushLe32(v, static_cast<uint32_t>(f1.size()));
+    pushBytes(v, f1);
+    return v;
+}
+
+// ---- 汽车协议帧构造 ----
+// DoIP 帧：Ethernet/IPv4/TCP(13400) + DoIP 头（ISO 13400-2:2012）+ 负载
+std::vector<unsigned char> doipTcpFrame(uint16_t payloadType,
+                                        const std::vector<unsigned char>& body)
+{
+    std::vector<unsigned char> doip;
+    pushByte(doip, 0x02); // version
+    pushByte(doip, 0xFD); // inverse version
+    pushBE16(doip, payloadType);
+    pushBE32(doip, static_cast<uint32_t>(body.size()));
+    pushBytes(doip, body);
+    uint16_t tcpLen = static_cast<uint16_t>(20 + doip.size());
+    auto     eth    = ethHeader(0x0800);
+    auto     ip     = ipv4Header("192.168.1.10", "192.168.1.20", 6,
+                                 static_cast<uint16_t>(20 + tcpLen));
+    auto tcp = tcpHeader(49152, 13400, 0x18); // PSH+ACK
+    std::vector<unsigned char> frame;
+    pushBytes(frame, eth);
+    pushBytes(frame, ip);
+    pushBytes(frame, tcp);
+    pushBytes(frame, doip);
+    return frame;
+}
+
+// SocketCAN（DLT 227）经典帧：can_id(LE) + DLC + 数据（数据区从偏移 8 起）
+std::vector<unsigned char> canSocketcanFrame(uint32_t canId, uint8_t dlc,
+                                             const std::vector<unsigned char>& data)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, canId);
+    pushByte(v, dlc);
+    pushByte(v, 0); // pad
+    pushByte(v, 0); // res0
+    pushByte(v, 0); // len8_dlc
+    pushBytes(v, data);
+    return v;
+}
+
+// SocketCAN（DLT 227）CAN FD 帧：can_id(LE) + flags + len + 数据
+std::vector<unsigned char> canFdSocketcanFrame(uint32_t canId, uint8_t flags, uint8_t len,
+                                               const std::vector<unsigned char>& data)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, canId);
+    pushByte(v, flags);
+    pushByte(v, len);
+    pushByte(v, 0); // res0
+    pushByte(v, 0); // res1
+    pushBytes(v, data);
+    return v;
+}
+
+// 原始 CAN（DLT 228/229）：can_id(LE，高 3 位 EFF/RTR/ERR 标志) + 数据
+std::vector<unsigned char> rawCanFrame(uint32_t canId, const std::vector<unsigned char>& data)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, canId);
+    pushBytes(v, data);
+    return v;
+}
 } // namespace
 
 // ---- NativePacketParser ----
@@ -376,6 +457,159 @@ TEST(NativeParserTest, DisplayFilterBasics)
     EXPECT_FALSE(badErr.empty());
 }
 
+// ---- 汽车协议：DoIP / UDS / CAN ----
+TEST(NativeParserTest, ParsesDoipUdsRequest)
+{
+    // 诊断消息（0x8001）：源地址(2) + 目标地址(2) + UDS（DiagnosticSessionControl 请求）
+    std::vector<unsigned char> body;
+    pushBE16(body, 0x0E80); // 源逻辑地址
+    pushBE16(body, 0x0001); // 目标逻辑地址
+    pushByte(body, 0x10);   // SID DiagnosticSessionControl
+    pushByte(body, 0x03);   // 子功能 extendedDiagnosticSession
+    auto frame = doipTcpFrame(0x8001, body);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "UDS");
+    EXPECT_EQ(p.dst_port, 13400);
+    EXPECT_NE(p.info.find("DiagnosticSessionControl"), std::string::npos);
+    EXPECT_NE(p.info.find("0x10"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesDoipRoutingActivation)
+{
+    // 路由激活请求（0x0005），无 UDS 负载
+    std::vector<unsigned char> body;
+    pushByte(body, 0x0E);
+    pushByte(body, 0x80);
+    pushByte(body, 0x00); // 激活类型
+    pushByte(body, 0x00);
+    pushByte(body, 0x00); // 保留
+    pushByte(body, 0x00);
+    pushByte(body, 0x00); // 保留
+    pushByte(body, 0x00);
+    auto frame = doipTcpFrame(0x0005, body);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DoIP");
+    EXPECT_NE(p.info.find("Routing activation request"), std::string::npos);
+    EXPECT_NE(p.info.find("0x0005"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesDoipUdsNegativeResponse)
+{
+    // UDS 负响应：7F <SID> <NRC>
+    std::vector<unsigned char> body;
+    pushBE16(body, 0x0E80);
+    pushBE16(body, 0x0001);
+    pushByte(body, 0x7F); // 负响应
+    pushByte(body, 0x10); // 原服务
+    pushByte(body, 0x31); // NRC RequestOutOfRange
+    auto frame = doipTcpFrame(0x8001, body);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "UDS");
+    EXPECT_NE(p.info.find("Negative response"), std::string::npos);
+    EXPECT_NE(p.info.find("Request out of range"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesCanSocketcan)
+{
+    std::vector<unsigned char> data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    auto frame = canSocketcanFrame(0x123, 0x08, data);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 227));
+    EXPECT_EQ(p.protocol, "CAN");
+    EXPECT_EQ(p.can_id, 0x123u);
+    EXPECT_NE(p.info.find("0x123"), std::string::npos);
+    EXPECT_NE(p.info.find("DLC=8"), std::string::npos);
+    EXPECT_NE(p.info.find("01 02 03 04"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesCanFdSocketcan)
+{
+    std::vector<unsigned char> data(64, 0xAA);
+    auto frame = canFdSocketcanFrame(0x1FED, 0x80, 64, data); // FDF=0x80 → CAN FD
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 227));
+    EXPECT_EQ(p.protocol, "CAN FD");
+    EXPECT_EQ(p.can_id, 0x1FEDu);
+    EXPECT_NE(p.info.find("CAN FD"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesUdsOverCanSingleFrame)
+{
+    // CAN 0x123 上的 ISO-TP 单帧：PCI=0x02（长度 2），UDS = 3E 00（TesterPresent）
+    std::vector<unsigned char> data;
+    pushHex(data, "023e000000000000");
+    auto frame = canSocketcanFrame(0x123, 0x08, data);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 227));
+    EXPECT_EQ(p.protocol, "UDS");
+    EXPECT_EQ(p.can_id, 0x123u);
+    EXPECT_NE(p.info.find("TesterPresent"), std::string::npos);
+}
+
+TEST(NativeParserTest, ParsesRawCan)
+{
+    // 数据区不以已知 UDS SID 开头 → 按普通 CAN 帧解析
+    std::vector<unsigned char> data = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    auto frame = rawCanFrame(0x456, data);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p, 228));
+    EXPECT_EQ(p.protocol, "CAN");
+    EXPECT_EQ(p.can_id, 0x456u);
+    EXPECT_NE(p.info.find("0x456"), std::string::npos);
+    // 29 位扩展帧（EFF 标志）
+    auto ext = rawCanFrame(0x80000000 | 0x1FED123, data);
+    Packet pe;
+    ASSERT_TRUE(NativePacketParser::parseFrame(ext.data(), static_cast<uint32_t>(ext.size()), pe,
+                                               228));
+    EXPECT_EQ(pe.can_id, 0x1FED123u);
+    EXPECT_NE(pe.info.find("0x01fed123"), std::string::npos);
+    // 原始 CAN 上携带 UDS（数据区以已知 SID 0x3E 开头）
+    std::vector<unsigned char> udsData = {0x3E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    auto uframe = rawCanFrame(0x7E0, udsData);
+    Packet pu;
+    ASSERT_TRUE(NativePacketParser::parseFrame(uframe.data(),
+                                               static_cast<uint32_t>(uframe.size()), pu, 228));
+    EXPECT_EQ(pu.protocol, "UDS");
+    EXPECT_NE(pu.info.find("TesterPresent"), std::string::npos);
+}
+
+TEST(NativeParserTest, AutomotiveDisplayFilters)
+{
+    std::vector<unsigned char> body;
+    pushBE16(body, 0x0E80);
+    pushBE16(body, 0x0001);
+    pushByte(body, 0x3E); // TesterPresent
+    pushByte(body, 0x00);
+    auto doip = doipTcpFrame(0x8001, body);
+    std::vector<unsigned char> canData = {0, 0, 0, 0, 0, 0, 0, 0};
+    auto can  = canSocketcanFrame(0x123, 8, canData);
+    Packet doipP, canP;
+    ASSERT_TRUE(NativePacketParser::parseFrame(doip.data(), static_cast<uint32_t>(doip.size()),
+                                               doipP));
+    ASSERT_TRUE(NativePacketParser::parseFrame(can.data(), static_cast<uint32_t>(can.size()), canP,
+                                               227));
+    std::string err;
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("doip", doipP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("uds", doipP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("doip || uds", doipP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("can", canP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("can.id==0x123", canP, &err));
+    EXPECT_TRUE(NativePacketParser::matchDisplayFilter("can.id==291", canP, &err)); // 十进制
+    EXPECT_FALSE(NativePacketParser::matchDisplayFilter("can.id==0x124", canP, &err));
+    EXPECT_FALSE(NativePacketParser::matchDisplayFilter("doip", canP, &err));
+    EXPECT_TRUE(err.empty());
+}
+
 // ---- NativeAnalyzer（离线 pcap 解析）----
 class NativeAnalyzerTest : public ::testing::Test {
 protected:
@@ -443,6 +677,46 @@ TEST_F(NativeAnalyzerTest, AnalyzesPcapAndHex)
     std::vector<uint32_t> bad;
     EXPECT_FALSE(analyzer.getFramesByDisplayFilter("bogus.field==1", bad, &err));
     EXPECT_FALSE(err.empty());
+}
+
+TEST_F(NativeAnalyzerTest, AnalyzesCanLinkTypePcap)
+{
+    // 链路类型 227（SocketCAN）的 pcap：解析 CAN 帧 + 详情树 + 显示过滤
+    std::vector<unsigned char> data;
+    pushHex(data, "023e000000000000"); // ISO-TP 单帧：TesterPresent
+    auto canFrame = canSocketcanFrame(0x123, 8, data);
+    auto bytes    = makePcapFileLinkType(227, canFrame);
+    std::string canPath = "test_data/native_can.pcap";
+    {
+        std::ofstream out(canPath.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+    NativeAnalyzer analyzer;
+    std::vector<std::shared_ptr<Packet>> packets;
+    ASSERT_TRUE(analyzer.analyzeFile(canPath, packets));
+    ASSERT_EQ(packets.size(), 1u);
+    EXPECT_EQ(packets[0]->protocol, "UDS");
+    EXPECT_EQ(packets[0]->can_id, 0x123u);
+    EXPECT_NE(packets[0]->info.find("TesterPresent"), std::string::npos);
+
+    DetailNode root;
+    ASSERT_TRUE(analyzer.getPacketDetailTree(1, root));
+    bool hasCan = false, hasUds = false;
+    for (const auto& c : root.children)
+    {
+        if (c.label == "Controller Area Network")
+            hasCan = true;
+        if (c.label == "Unified Diagnostic Services")
+            hasUds = true;
+    }
+    EXPECT_TRUE(hasCan);
+    EXPECT_TRUE(hasUds);
+
+    std::vector<uint32_t> frames;
+    ASSERT_TRUE(analyzer.getFramesByDisplayFilter("can.id==0x123 && uds", frames));
+    ASSERT_EQ(frames.size(), 1u);
+    std::remove(canPath.c_str());
 }
 
 // ---- AnalysisSession native 集成（无 tshark 时后端自动降级）----
@@ -990,4 +1264,206 @@ TEST(NativeParserTest, ParsesSll2)
     EXPECT_EQ(p.dst_ip, "10.2.2.2");
     EXPECT_EQ(p.dst_port, 53);
     EXPECT_EQ(p.transport, "UDP");
+}
+
+// ---- DNS 压缩指针（RFC 1035 §4.1.4）----
+TEST(NativeParserTest, ParsesDnsCnameWithCompressionPointer)
+{
+    std::vector<unsigned char> dns;
+    pushBE16(dns, 0x9999);
+    pushBE16(dns, 0x8180);
+    pushBE16(dns, 1); // QDCOUNT
+    pushBE16(dns, 1); // ANCOUNT
+    pushBE16(dns, 0);
+    pushBE16(dns, 0);
+    // question: example.com A（起始偏移 12）
+    pushByte(dns, 7); pushHex(dns, "6578616d706c65");
+    pushByte(dns, 3); pushHex(dns, "636f6d");
+    pushByte(dns, 0);
+    pushBE16(dns, 1); pushBE16(dns, 1);
+    // answer：name 用压缩指针 0xc00c 指回 offset 12，type=CNAME，rdata 也是指回 offset 12 的压缩指针
+    // （CNAME 目标本身就是 example.com）——验证 rdata 域名解析能跟随压缩指针，而不是截断/乱码。
+    pushHex(dns, "c00c");
+    pushBE16(dns, 5); pushBE16(dns, 1); pushBE32(dns, 300);
+    pushBE16(dns, 2); pushHex(dns, "c00c");
+
+    auto frame = udpPayloadFrame("8.8.8.8", "192.168.1.10", 53, 53000, dns);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "DNS");
+    EXPECT_NE(p.info.find("CNAME example.com"), std::string::npos);
+}
+
+// ---- SSH（RFC 4253 §4.2，版本交换 banner）----
+TEST(NativeParserTest, ParsesSshBanner)
+{
+    auto payload = strVec("SSH-2.0-OpenSSH_9.6\r\n");
+    auto frame   = tcpPayloadFrame("192.168.1.10", "192.168.1.20", 51000, 22, payload);
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "SSH");
+    EXPECT_NE(p.info.find("SSH-2.0-OpenSSH_9.6"), std::string::npos);
+
+    DetailNode root;
+    ASSERT_TRUE(NativePacketParser::buildDetailTree(
+        frame.data(), static_cast<uint32_t>(frame.size()), 1, 1, root));
+    bool hasSsh = false;
+    for (const auto& c : root.children)
+    {
+        if (c.label != "SSH Protocol")
+            continue;
+        hasSsh = true;
+        ASSERT_FALSE(c.children.empty());
+        EXPECT_NE(c.children[0].value.find("SSH-2.0-OpenSSH_9.6"), std::string::npos);
+    }
+    EXPECT_TRUE(hasSsh);
+}
+
+// ---- IPv6 分片（Fragment Header，proto 44）----
+TEST(NativeParserTest, MarksIpv6Fragment)
+{
+    std::vector<unsigned char> frame = ethHeader(0x86dd);
+    pushBE32(frame, 0x60000000);
+    pushBE16(frame, 8 + 20); // payload len：Fragment Header(8) + TCP 头(20)
+    pushByte(frame, 44);     // next header = Fragment Header
+    pushByte(frame, 64);
+    pushHex(frame, "fe800000000000000000000000000001");
+    pushHex(frame, "fe800000000000000000000000000002");
+    // Fragment Header：next(1)=TCP(6) reserved(1) fragOffset+flags(2) id(4)
+    pushByte(frame, 6);
+    pushByte(frame, 0);
+    pushBE16(frame, 0x0008 | 0x0001); // offset=1（*8=8 字节）+ M=1（还有更多分片）
+    pushBE32(frame, 0x12345678);
+    pushBytes(frame, tcpHeader(51000, 5555, 0x10));
+
+    Packet p;
+    ASSERT_TRUE(NativePacketParser::parseFrame(frame.data(), static_cast<uint32_t>(frame.size()),
+                                               p));
+    EXPECT_EQ(p.protocol, "TCP");
+
+    DetailNode root;
+    ASSERT_TRUE(NativePacketParser::buildDetailTree(
+        frame.data(), static_cast<uint32_t>(frame.size()), 1, 1, root));
+    bool hasFrag = false;
+    for (const auto& layer : root.children)
+        if (layer.label.find("Internet Protocol") != std::string::npos)
+            for (const auto& f : layer.children)
+                if (f.label == "Fragment") hasFrag = true;
+    EXPECT_TRUE(hasFrag);
+}
+
+// ---- ISO-TP（ISO 15765-2）多帧重组 ----
+// 10 字节 UDS 报文（ReadDataByIdentifier 正响应），拆成 First Frame(6 字节) + 1 个 Consecutive Frame(4 字节)。
+std::vector<unsigned char> isoTpUdsPayload()
+{
+    return {0x62, 0xF1, 0x90, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47};
+}
+std::vector<unsigned char> isoTpFirstFrame(const std::vector<unsigned char>& payload)
+{
+    std::vector<unsigned char> d;
+    pushByte(d, 0x10);
+    pushByte(d, static_cast<unsigned char>(payload.size()));
+    for (size_t i = 0; i < 6 && i < payload.size(); ++i) pushByte(d, payload[i]);
+    return d;
+}
+std::vector<unsigned char> isoTpConsecutiveFrame(const std::vector<unsigned char>& payload,
+                                                 uint8_t seq)
+{
+    std::vector<unsigned char> d;
+    pushByte(d, static_cast<unsigned char>(0x20 | (seq & 0x0F)));
+    for (size_t i = 6; i < payload.size(); ++i) pushByte(d, payload[i]);
+    while (d.size() < 8) pushByte(d, 0xAA); // CAN 帧补齐到 8 字节（填充）
+    return d;
+}
+
+TEST(NativeParserTest, ParsesIsoTpMultiFrame)
+{
+    auto payload = isoTpUdsPayload();
+    auto ffFrame = canSocketcanFrame(0x7E8, 8, isoTpFirstFrame(payload));
+    auto cfFrame = canSocketcanFrame(0x7E8, 8, isoTpConsecutiveFrame(payload, 1));
+
+    NativePacketParser::IsoTpReassembler isoTp;
+    Packet pFf;
+    ASSERT_TRUE(NativePacketParser::parseFrame(
+        ffFrame.data(), static_cast<uint32_t>(ffFrame.size()), pFf, 227, &isoTp));
+    EXPECT_NE(pFf.protocol, "UDS"); // 未凑满，不应误报完成
+    EXPECT_NE(pFf.info.find("First Frame"), std::string::npos);
+    EXPECT_NE(pFf.info.find("Len=10"), std::string::npos);
+
+    Packet pCf;
+    ASSERT_TRUE(NativePacketParser::parseFrame(
+        cfFrame.data(), static_cast<uint32_t>(cfFrame.size()), pCf, 227, &isoTp));
+    EXPECT_EQ(pCf.protocol, "UDS");
+    EXPECT_NE(pCf.info.find("ReadDataByIdentifier"), std::string::npos);
+}
+
+// 多帧（小端经典 pcap）：供 NativeAnalyzer 集成测试构造含 FF+CF 的 CAN 抓包文件。
+std::vector<unsigned char> makePcapFileLinkTypeMulti(
+    uint32_t linkType, const std::vector<std::vector<unsigned char>>& frames)
+{
+    std::vector<unsigned char> v;
+    pushLe32(v, 0xa1b2c3d4);
+    pushLe16(v, 2);
+    pushLe16(v, 4);
+    pushLe32(v, 0);
+    pushLe32(v, 0);
+    pushLe32(v, 65535);
+    pushLe32(v, linkType);
+    for (const auto& f : frames)
+    {
+        pushLe32(v, 1); // ts_sec
+        pushLe32(v, 0);
+        pushLe32(v, static_cast<uint32_t>(f.size()));
+        pushLe32(v, static_cast<uint32_t>(f.size()));
+        pushBytes(v, f);
+    }
+    return v;
+}
+
+TEST_F(NativeAnalyzerTest, AnalyzesCanIsoTpMultiFrameAndReplaysDetailTree)
+{
+    auto payload = isoTpUdsPayload();
+    auto ff       = canSocketcanFrame(0x7E8, 8, isoTpFirstFrame(payload));
+    auto cf       = canSocketcanFrame(0x7E8, 8, isoTpConsecutiveFrame(payload, 1));
+    auto bytes    = makePcapFileLinkTypeMulti(227, {ff, cf});
+    std::string path = "test_data/native_isotp.pcap";
+    {
+        std::ofstream out(path.c_str(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+
+    NativeAnalyzer analyzer;
+    std::vector<std::shared_ptr<Packet>> packets;
+    ASSERT_TRUE(analyzer.analyzeFile(path, packets));
+    ASSERT_EQ(packets.size(), 2u);
+    EXPECT_NE(packets[0]->protocol, "UDS"); // First Frame 单独看未完成
+    EXPECT_EQ(packets[1]->protocol, "UDS"); // Consecutive Frame 补满后识别为 UDS
+    EXPECT_NE(packets[1]->info.find("ReadDataByIdentifier"), std::string::npos);
+
+    // 只查最后一帧（不预先查前面的帧）：getPacketDetailTree 必须自行重放历史帧，
+    // 才能在按需构建详情树时也看到完整重组后的 UDS 内容。
+    DetailNode root;
+    ASSERT_TRUE(analyzer.getPacketDetailTree(2, root));
+    bool hasUds = false;
+    for (const auto& c : root.children)
+        if (c.label == "Unified Diagnostic Services")
+            hasUds = true;
+    EXPECT_TRUE(hasUds);
+
+    // 乱序往回跳到第 1 帧、再跳回第 2 帧：增量重放缓存必须整体重置重放，不能残留
+    // 跳回前的状态导致重复消费 First Frame 或漏算 Consecutive Frame。
+    DetailNode root1;
+    ASSERT_TRUE(analyzer.getPacketDetailTree(1, root1));
+    DetailNode root2;
+    ASSERT_TRUE(analyzer.getPacketDetailTree(2, root2));
+    bool hasUdsAgain = false;
+    for (const auto& c : root2.children)
+        if (c.label == "Unified Diagnostic Services")
+            hasUdsAgain = true;
+    EXPECT_TRUE(hasUdsAgain);
+
+    std::remove(path.c_str());
 }

--- a/web/app.js
+++ b/web/app.js
@@ -67,6 +67,9 @@ function protocolClass(proto) {
     const p = (proto || '').toUpperCase();
     if (p.includes('TCP')) return '#8cbfff';
     if (p.includes('UDP')) return '#73d9bf';
+    if (p.includes('DoIP')) return '#f27366';
+    if (p.includes('UDS')) return '#ff9933';
+    if (p.includes('CAN')) return '#66bf8c';
     if (p.includes('DNS')) return '#ffb85a';
     if (p.includes('HTTP')) return '#8ce673';
     if (p.includes('TLS') || p.includes('SSL')) return '#cc99ff';
@@ -184,6 +187,7 @@ function rowHtml(p) {
         + `<td class="proto" style="color:${protocolClass(p.protocol)}">${escapeHtml(p.protocol)}</td>`
         + `<td>${p.len}</td>`
         + `<td>${escapeHtml(p.info)}</td>`
+        + `<td>${p.proc_pid ? escapeHtml(p.proc_name) + ' (' + p.proc_pid + ')' : ''}</td>`
         + `</tr>`;
 }
 
@@ -434,12 +438,23 @@ function renderSessions() {
     const all = aggSource();
     const cat = parseInt($('sessionCategory').value, 10);
     const map = new Map();
+    // CAN 链路报文无 IP 层，从不经过 TCP/UDP 解析：transport 恒为空，protocol 只会是
+    // "UDS"（直接 UDS-over-CAN / ISO-TP 重组完成）或以 "CAN" 开头（普通 CAN/CAN FD 帧）。
+    const isCanLink = (p) => !p.transport && (String(p.protocol || '').startsWith('CAN') || p.protocol === 'UDS');
     for (const p of all) {
-        if (!p.src_ip || !p.dst_ip) continue;
-        const a = p.src_ip + ':' + p.src_port, b = p.dst_ip + ':' + p.dst_port;
-        const key = a < b ? a + '|' + b : b + '|' + a;
+        let key, mk;
+        if (p.src_ip && p.dst_ip) {
+            const a = p.src_ip + ':' + p.src_port, b = p.dst_ip + ':' + p.dst_port;
+            key = a < b ? a + '|' + b : b + '|' + a;
+            mk = () => ({ a: a < b ? a : b, b: a < b ? b : a, transport: p.transport || '', protocols: new Set(), packets: 0, bytes: 0 });
+        } else if (isCanLink(p)) {
+            key = 'CAN|' + (p.can_id || 0);
+            mk = () => ({ a: 'CAN ID 0x' + (p.can_id || 0).toString(16), b: '(总线广播)', transport: 'CAN', protocols: new Set(), packets: 0, bytes: 0 });
+        } else {
+            continue;
+        }
         let si = map.get(key);
-        if (!si) { si = { a: a < b ? a : b, b: a < b ? b : a, transport: p.transport || '', protocols: new Set(), packets: 0, bytes: 0 }; map.set(key, si); }
+        if (!si) { si = mk(); map.set(key, si); }
         if (p.protocol) si.protocols.add(p.protocol);
         si.packets++; si.bytes += p.len || 0;
     }
@@ -452,6 +467,9 @@ function renderSessions() {
             case 4: return has(si, 'HTTP');
             case 5: return has(si, 'TLS') || has(si, 'SSL');
             case 6: return has(si, 'SSH');
+            case 7: return has(si, 'DoIP');
+            case 8: return has(si, 'UDS');
+            case 9: return si.transport === 'CAN';
             default: return true;
         }
     };
@@ -537,6 +555,17 @@ $('btnExportCsv').addEventListener('click', async () => {
         const r = await postJSON('/api/export/csv', { path });
         setStatus('已导出 CSV: ' + r.path);
     } catch (e) { setStatus('导出失败：' + e.message); }
+});
+
+// ---------- 保存 PCAP ----------
+$('btnExportPcap').addEventListener('click', async () => {
+    const path = $('pcapSavePath').value.trim();
+    if (!path) { setStatus('请输入 PCAP 保存路径'); return; }
+    setStatus('保存 PCAP 中...');
+    try {
+        const r = await postJSON('/api/export/pcap', { path });
+        setStatus('已保存 PCAP: ' + r.path);
+    } catch (e) { setStatus('保存失败：' + e.message); }
 });
 
 // ---------- 分页 Tab 切换 ----------

--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,8 @@
             <span class="label">导出</span>
             <input id="csvPath" type="text" placeholder="CSV 保存路径，如 data/export.csv" size="24">
             <button id="btnExportCsv">导出 CSV</button>
+            <input id="pcapSavePath" type="text" placeholder="PCAP 保存路径，如 data/export.pcap" size="24">
+            <button id="btnExportPcap">保存 PCAP</button>
         </div>
     </div>
 
@@ -78,7 +80,7 @@
                             <thead>
                                 <tr>
                                     <th>No.</th><th>时间</th><th>源</th><th>源归属地</th><th>源端口</th>
-                                    <th>目的</th><th>目的归属地</th><th>目的端口</th><th>协议</th><th>大小</th><th>信息</th>
+                                    <th>目的</th><th>目的归属地</th><th>目的端口</th><th>协议</th><th>大小</th><th>信息</th><th>进程</th>
                                 </tr>
                             </thead>
                             <tbody id="packetsBody"></tbody>
@@ -111,7 +113,8 @@
                     <option value="0">全部会话</option><option value="1">TCP会话</option>
                     <option value="2">UDP会话</option><option value="3">DNS会话</option>
                     <option value="4">HTTP会话</option><option value="5">SSL/TLS会话</option>
-                    <option value="6">SSH会话</option>
+                    <option value="6">SSH会话</option><option value="7">DoIP会话</option>
+                    <option value="8">UDS会话</option><option value="9">CAN会话</option>
                 </select>
                 <span id="sessionCount"></span>
             </div>


### PR DESCRIPTION
- 自研解析引擎：madvise 顺序预读、MAC/IPv6/UDS 字符串拼接去堆分配、 CAN 详情查询增量重放 ISO-TP 重组状态（O(n²) -> 摊还线性）
- 桌面 GUI：会话/统计表补齐 ImGuiListClipper 虚拟化，聚合 map 换 unordered_map，实时抓包场景下聚合重建节流到 ~300ms
- Web/会话查询：packetsToJson 增加零往返 rapidjson::Value 重载与 StringRef 零拷贝字段，显示过滤结果改双指针归并（O(N log F) -> O(N+F)）
- 新增实时抓包进程归属（ProcessResolver）与 CAN 测试 pcap 生成脚本